### PR TITLE
Webhook方式表示改善

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ npm i @sugityan/playwright-slack-notification
 `.env` に Webhook URL を設定します（`webhookUrl` をコードで直接渡す場合は省略可能です）：
 
 ```env
-SLACK_WEBHOOK_URL=https://hooks.slack.com/services/YOUR_WEBHOOK_URL
+SLACK_WEBHOOK_URL=YOUR_WEBHOOK_URL
 ```
 
 #### B. Slack Bot Token 方式（スレッド投稿したい場合）
@@ -42,7 +42,7 @@ SLACK_BOT_CHANNEL_ID=C1234567890
 Bot 方式を使う場合、Webhook URL (`SLACK_WEBHOOK_URL`) は不要です。
 ### 3. 通常通知を送る
 
-アプリコードで以下のように呼び出します。環境変数 `SLACK_WEBHOOK_URL` が自動的に使用されます：
+以下のように呼び出します。
 
 ```ts
 import { sendNotification } from '@sugityan/playwright-slack-notification';
@@ -97,7 +97,9 @@ export default defineConfig({
       // 失敗時のみ通知（デフォルト）
       notifyMode: 'failure', // 'failure' | 'always'
 
-      // エラー内容（reason/details）を表示するか
+      // エラー詳細を表示するか（デフォルト: true）
+      // true: スタックトレース含む詳細を表示
+      // false: テスト名とロケーションのみ表示
       showErrorDetails: true,
 
       channel: '#ci',
@@ -136,8 +138,16 @@ export default defineConfig({
 
 `showErrorDetails` の指定（Webhook / Bot 共通）:
 
-- `true` (デフォルト): エラー内容を表示
-- `false`: エラー内容を非表示（テスト名や件数のみ通知）
+- `true` (デフォルト): エラーの詳細情報（スタックトレース含む）を表示
+  - Webhook方式: テスト名 + `details:` セクションにコードブロックでエラー全文を表示
+  - Bot Thread方式: メイン投稿はテスト名のみ、スレッドにエラーサマリーを投稿
+- `false`: エラーの詳細を非表示（テスト名とロケーションのみ通知）
+  - どちらの方式でもエラー内容は表示されません
+
+**表示例（Webhook方式、`showErrorDetails: true`）:**
+
+
+<img src="Screenshot 2026-05-09 at 0.08.17.png" width="600" alt="Webhook通知例">
 
 Slack bot user でスレッド投稿する場合は、以下を設定してください。
 

--- a/src/playwrightReporter.ts
+++ b/src/playwrightReporter.ts
@@ -33,6 +33,16 @@ function stripAnsi(text: string): string {
   return text.replace(/\u001b\[[0-9;]*m/g, '').replace(/\x1b\[[0-9;]*m/g, '');
 }
 
+function toRelativePath(absolutePath: string): string {
+  const cwd = process.cwd();
+  if (absolutePath.startsWith(cwd)) {
+    const relative = absolutePath.slice(cwd.length);
+    // Remove leading slash if present
+    return relative.startsWith('/') ? relative.slice(1) : relative;
+  }
+  return absolutePath;
+}
+
 function formatErrorSummary(error?: string): string | undefined {
   if (!error) return undefined;
 
@@ -50,6 +60,11 @@ function formatErrorSummary(error?: string): string | undefined {
     .join(' | ');
 
   return summary.length > 0 ? summary : lines[0];
+}
+
+function formatErrorSummaryForThread(error?: string): string {
+  const summary = formatErrorSummary(error);
+  return summary ?? 'Unknown error';
 }
 
 function formatErrorDetails(error: string, maxLines: number, maxChars: number): string | undefined {
@@ -108,7 +123,7 @@ export class PlaywrightSlackReporter implements Reporter {
     const title = test.titlePath().join(' › ');
     const project = test.parent.project()?.name;
     const location = test.location
-      ? `${test.location.file}:${test.location.line}:${test.location.column}`
+      ? `${toRelativePath(test.location.file)}:${test.location.line}:${test.location.column}`
       : undefined;
     const error = result.error?.message;
 
@@ -149,10 +164,6 @@ export class PlaywrightSlackReporter implements Reporter {
         const where = [failure.project, failure.location].filter(Boolean).join(' ');
         lines.push(`- ${failure.title}${where ? ` (${where})` : ''}`);
 
-        if (this.options.showErrorDetails) {
-          const summary = formatErrorSummary(failure.error);
-          if (summary) lines.push(`  reason: ${summary}`);
-        }
 
         if (this.options.showErrorDetails && !canUseBotThread && failure.error) {
           const details = formatErrorDetails(
@@ -197,8 +208,8 @@ export class PlaywrightSlackReporter implements Reporter {
         const detailLines: string[] = ['Failed test error reasons:'];
 
         for (const failure of this.failures.slice(0, this.options.maxFailures)) {
-          const summary = formatErrorSummary(failure.error);
-          detailLines.push(`- ${summary ?? 'Unknown error'}`);
+          const errorSummary = formatErrorSummaryForThread(failure.error);
+          detailLines.push(`- ${errorSummary}`);
         }
 
         if (this.failures.length > this.options.maxFailures) {

--- a/tests/playwright-reporter.test.ts
+++ b/tests/playwright-reporter.test.ts
@@ -303,4 +303,41 @@ describe('PlaywrightSlackReporter', () => {
     assert.doesNotMatch(payloads[0].text, /reason:/);
     assert.doesNotMatch(payloads[0].text, /Expected:/);
   });
+
+  it('converts absolute file paths to relative paths', async () => {
+    process.env.SLACK_WEBHOOK_URL = 'https://example.invalid/webhook';
+
+    const seen = { body: '' };
+    globalThis.fetch = (async (_input: unknown, init?: RequestInit) => {
+      seen.body = String(init?.body ?? '');
+      return new Response('ok', { status: 200 });
+    }) as typeof fetch;
+
+    const cwd = process.cwd();
+    const absolutePath = `${cwd}/apps/web/e2e/contact-form.spec.ts`;
+
+    const reporter = new PlaywrightSlackReporter();
+    reporter.onTestEnd?.(
+      {
+        titlePath: () => ['chromium', 'contact form', 'submit form'],
+        parent: { project: () => ({ name: 'web' }) },
+        location: { file: absolutePath, line: 114, column: 1 },
+      } as any,
+      {
+        status: 'failed',
+        error: {
+          message: 'Error: Form submission failed',
+        },
+      } as any,
+    );
+
+    await reporter.onEnd?.({ status: 'failed' } as any);
+
+    const payload = JSON.parse(seen.body) as { text: string };
+    assert.equal(typeof payload.text, 'string');
+    // Should contain relative path, not absolute path
+    assert.match(payload.text, /apps\/web\/e2e\/contact-form\.spec\.ts:114:1/);
+    // Should NOT contain the full absolute path
+    assert.doesNotMatch(payload.text, new RegExp(cwd.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')));
+  });
 });


### PR DESCRIPTION
 **エラー表示の改善**: Webhook方式で `reason` と `details` が重複していた問題を修正
  - 以前: `reason:` で1行サマリー、`details:` でコードブロックに全文を表示（内容が重複）
  - 現在: `details:` のみにエラー全文を表示
- **`showErrorDetails` オプションの動作を明確化**:
  - `true`: エラー詳細をコードブロックで表示（Webhook方式）またはスレッド投稿（Bot方式）
  - `false`: テスト名とロケーションのみ表示、エラー内容は非表示
- **ファイルパスを相対パスで表示**: 絶対パス（`/Users/...`）ではなく、プロジェクトルートからの相対パス（`apps/web/e2e/contact-form.spec.ts`）を表示するように改善