### PR TITLE
Fix thread type slack notification

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,8 +10,11 @@
       "license": "MIT",
       "devDependencies": {
         "@playwright/test": "^1.58.2",
-        "@types/node": "^25.5.0",
+        "@types/node": "^25.6.2",
         "typescript": "^5.9.3"
+      },
+      "peerDependencies": {
+        "@playwright/test": ">=1.40.0"
       }
     },
     "node_modules/@playwright/test": {
@@ -31,13 +34,13 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "25.5.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.5.0.tgz",
-      "integrity": "sha512-jp2P3tQMSxWugkCUKLRPVUpGaL5MVFwF8RDuSRztfwgN1wmqJeMSbKlnEtQqU8UrhTmzEmZdu2I6v2dpp7XIxw==",
+      "version": "25.6.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.6.2.tgz",
+      "integrity": "sha512-sokuT28dxf9JT5Kady1fsXOvI4HVpjZa95NKT5y9PNTIrs2AsobR4GFAA90ZG8M+nxVRLysCXsVj6eGC7Vbrlw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~7.18.0"
+        "undici-types": "~7.19.0"
       }
     },
     "node_modules/fsevents": {
@@ -102,9 +105,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "7.18.2",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
-      "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
+      "version": "7.19.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.19.2.tgz",
+      "integrity": "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==",
       "dev": true,
       "license": "MIT"
     }

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
   "homepage": "https://github.com/sugityan/playwright-slack-notification#readme",
   "devDependencies": {
     "@playwright/test": "^1.58.2",
-    "@types/node": "^25.5.0",
+    "@types/node": "^25.6.2",
     "typescript": "^5.9.3"
   },
   "peerDependencies": {

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -24,6 +24,7 @@ export const DEFAULTS = {
   RETRY_DELAY_MS: 500,
   SHOW_ERROR_DETAILS: true,
   ERROR_DETAILS_IN_THREAD: false,
+  SPLIT_THREAD_MESSAGE_PER_TEST: false,
   NOTIFY_MODE: 'failure' as const,
 } as const;
 

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,0 +1,36 @@
+/**
+ * Environment variable names used throughout the application
+ */
+export const ENV_VARS = {
+  SLACK_WEBHOOK_URL: 'SLACK_WEBHOOK_URL',
+  SLACK_BOT_TOKEN: 'SLACK_BOT_TOKEN',
+  SLACK_BOT_CHANNEL_ID: 'SLACK_BOT_CHANNEL_ID',
+  PLAYWRIGHT_SLACK_NOTIFY: 'PLAYWRIGHT_SLACK_NOTIFY',
+  GITHUB_REPOSITORY: 'GITHUB_REPOSITORY',
+  GITHUB_SHA: 'GITHUB_SHA',
+  GITHUB_RUN_ID: 'GITHUB_RUN_ID',
+  GITHUB_SERVER_URL: 'GITHUB_SERVER_URL',
+} as const;
+
+/**
+ * Default configuration values for the Playwright reporter
+ */
+export const DEFAULTS = {
+  MAX_FAILURES: 5,
+  MAX_DETAIL_LINES: 80,
+  MAX_DETAIL_CHARS: 4000,
+  TIMEOUT_MS: 10_000,
+  RETRIES: 2,
+  RETRY_DELAY_MS: 500,
+  SHOW_ERROR_DETAILS: true,
+  ERROR_DETAILS_IN_THREAD: false,
+  NOTIFY_MODE: 'failure' as const,
+} as const;
+
+/**
+ * Emoji constants used in Slack messages
+ */
+export const EMOJIS = {
+  GREEN_CIRCLE: ':large_green_circle:',
+  RED_CIRCLE: ':red_circle:',
+} as const;

--- a/src/formatters.ts
+++ b/src/formatters.ts
@@ -1,0 +1,61 @@
+/**
+ * Utility functions for formatting error messages and details
+ */
+
+import { convertStackTraceToRelativePaths } from './pathUtils.ts';
+
+/**
+ * Removes ANSI color codes and escape sequences from text.
+ * This is useful for cleaning up terminal output before sending to Slack.
+ * 
+ * @param text - The text containing ANSI codes
+ * @returns The cleaned text without ANSI codes
+ * 
+ * @example
+ * stripAnsi('\u001b[31mError\u001b[0m') // Returns 'Error'
+ */
+export function stripAnsi(text: string): string {
+  return text.replace(/\u001b\[[0-9;]*m/g, '').replace(/\x1b\[[0-9;]*m/g, '');
+}
+
+/**
+ * Formats error details for display in Slack messages.
+ * - Strips ANSI color codes
+ * - Converts absolute paths to relative paths
+ * - Truncates to specified line and character limits
+ * - Adds truncation indicator when content is cut off
+ * 
+ * @param error - The raw error message/stack trace
+ * @param maxLines - Maximum number of lines to include
+ * @param maxChars - Maximum number of characters to include
+ * @returns The formatted error details or undefined if empty
+ * 
+ * @example
+ * const error = 'Error: Failed\n  at file.ts:10:5\n  at test.ts:20:3'
+ * formatErrorDetails(error, 2, 100) // Returns first 2 lines with relative paths
+ */
+export function formatErrorDetails(
+  error: string,
+  maxLines: number,
+  maxChars: number,
+): string | undefined {
+  const cleaned = stripAnsi(error).replace(/\r/g, '').trim();
+  if (!cleaned) return undefined;
+
+  // Convert absolute paths to relative paths in stack traces
+  const withRelativePaths = convertStackTraceToRelativePaths(cleaned);
+
+  const lines = withRelativePaths.split('\n');
+  const sliced = lines.slice(0, maxLines);
+  const truncatedByLines = lines.length > maxLines;
+  const joined = sliced.join('\n');
+
+  const truncatedByChars = joined.length > maxChars;
+  const detail = truncatedByChars ? `${joined.slice(0, maxChars)}\n...(truncated)` : joined;
+
+  if (truncatedByLines && !truncatedByChars) {
+    return `${detail}\n...(truncated)`;
+  }
+
+  return detail;
+}

--- a/src/messageBuilder.ts
+++ b/src/messageBuilder.ts
@@ -1,0 +1,201 @@
+/**
+ * Message building utilities for Slack notifications
+ */
+
+import type { FullResult } from '@playwright/test/reporter';
+
+import { EMOJIS, ENV_VARS } from './constants.ts';
+import { formatErrorDetails } from './formatters.ts';
+import type { Failure } from './reporterTypes.ts';
+
+/**
+ * Options for building Slack messages
+ */
+export interface MessageBuilderOptions {
+  /** Test result status */
+  resultStatus: string;
+  
+  /** Number of passed tests */
+  passedCount: number;
+  
+  /** Number of failed tests */
+  failedCount: number;
+  
+  /** List of test failures */
+  failures: Failure[];
+  
+  /** Maximum number of failures to include */
+  maxFailures: number;
+  
+  /** Maximum lines per error detail */
+  maxDetailLines: number;
+  
+  /** Maximum characters per error detail */
+  maxDetailChars: number;
+  
+  /** Whether to show error details */
+  showErrorDetails: boolean;
+  
+  /** Whether using bot thread mode (affects main message format) */
+  useBotThreadMode: boolean;
+}
+
+/**
+ * Builds the main Slack notification message
+ * 
+ * @param options - Message building options
+ * @returns The formatted message text
+ */
+export function buildMainMessage(options: MessageBuilderOptions): string {
+  const {
+    resultStatus,
+    passedCount,
+    failedCount,
+    failures,
+    maxFailures,
+    maxDetailLines,
+    maxDetailChars,
+    showErrorDetails,
+    useBotThreadMode,
+  } = options;
+
+  const lines: string[] = [];
+
+  // Header and test summary
+  lines.push(`Playwright E2E result: ${resultStatus}`);
+  lines.push(`${EMOJIS.GREEN_CIRCLE} Passed: ${passedCount} ${EMOJIS.RED_CIRCLE} Failed: ${failedCount}`);
+
+  // GitHub CI information
+  const repo = process.env[ENV_VARS.GITHUB_REPOSITORY];
+  const sha = process.env[ENV_VARS.GITHUB_SHA];
+  const runId = process.env[ENV_VARS.GITHUB_RUN_ID];
+  const serverUrl = process.env[ENV_VARS.GITHUB_SERVER_URL];
+
+  if (repo) lines.push(`repo: ${repo}`);
+  if (sha) lines.push(`sha: ${sha}`);
+  
+  if (repo && runId && serverUrl) {
+    const runUrl = `${serverUrl}/${repo}/actions/runs/${runId}`;
+    lines.push(`run: ${runUrl}`);
+  }
+
+  // Failures section
+  if (failures.length > 0) {
+    lines.push('failures:');
+    
+    for (const failure of failures.slice(0, maxFailures)) {
+      if (useBotThreadMode) {
+        // Bot thread mode: show only test name in main message
+        lines.push(`${EMOJIS.RED_CIRCLE} ${failure.testName}`);
+      } else {
+        // Webhook mode: show full details in main message
+        const where = [failure.project, failure.location].filter(Boolean).join(' ');
+        lines.push(`${EMOJIS.RED_CIRCLE} ${failure.title}${where ? ` (${where})` : ''}`);
+
+        if (showErrorDetails && failure.error) {
+          const details = formatErrorDetails(failure.error, maxDetailLines, maxDetailChars);
+          if (details) {
+            lines.push('  details:');
+            lines.push('```');
+            lines.push(details);
+            lines.push('```');
+          }
+        }
+      }
+    }
+
+    if (failures.length > maxFailures) {
+      lines.push(`...and ${failures.length - maxFailures} more`);
+    }
+  }
+
+  return lines.join('\n');
+}
+
+/**
+ * Builds the thread detail message for bot thread mode
+ * 
+ * @param options - Message building options
+ * @returns The formatted thread message text, or undefined if no details to show
+ */
+export function buildThreadDetailMessage(options: MessageBuilderOptions): string | undefined {
+  const {
+    failures,
+    maxFailures,
+    maxDetailLines,
+    maxDetailChars,
+    showErrorDetails,
+  } = options;
+
+  if (!showErrorDetails || failures.length === 0) {
+    return undefined;
+  }
+
+  const detailLines: string[] = [];
+
+  for (const failure of failures.slice(0, maxFailures)) {
+    // Test name and location
+    const where = [failure.project, failure.location].filter(Boolean).join(' ');
+    detailLines.push(`**${failure.title}**${where ? ` (${where})` : ''}`);
+
+    // Error details with full stack trace
+    if (failure.error) {
+      const details = formatErrorDetails(failure.error, maxDetailLines, maxDetailChars);
+      if (details) {
+        detailLines.push('```');
+        detailLines.push(details);
+        detailLines.push('```');
+      }
+    }
+
+    // Separator between errors (empty line)
+    detailLines.push('');
+  }
+
+  if (failures.length > maxFailures) {
+    detailLines.push(`...and ${failures.length - maxFailures} more`);
+  }
+
+  return detailLines.join('\n');
+}
+
+/**
+ * Convenience function to build both main and thread messages
+ * 
+ * @param result - Playwright test result
+ * @param passedCount - Number of passed tests
+ * @param failedCount - Number of failed tests
+ * @param failures - List of test failures
+ * @param config - Message configuration options
+ * @returns Object containing main message and optional thread message
+ */
+export function buildMessages(
+  result: FullResult,
+  passedCount: number,
+  failedCount: number,
+  failures: Failure[],
+  config: {
+    maxFailures: number;
+    maxDetailLines: number;
+    maxDetailChars: number;
+    showErrorDetails: boolean;
+    useBotThreadMode: boolean;
+  }
+): { mainMessage: string; threadMessage?: string } {
+  const options: MessageBuilderOptions = {
+    resultStatus: result.status,
+    passedCount,
+    failedCount,
+    failures,
+    maxFailures: config.maxFailures,
+    maxDetailLines: config.maxDetailLines,
+    maxDetailChars: config.maxDetailChars,
+    showErrorDetails: config.showErrorDetails,
+    useBotThreadMode: config.useBotThreadMode,
+  };
+
+  const mainMessage = buildMainMessage(options);
+  const threadMessage = config.useBotThreadMode ? buildThreadDetailMessage(options) : undefined;
+
+  return { mainMessage, threadMessage };
+}

--- a/src/messageBuilder.ts
+++ b/src/messageBuilder.ts
@@ -38,6 +38,9 @@ export interface MessageBuilderOptions {
   
   /** Whether using bot thread mode (affects main message format) */
   useBotThreadMode: boolean;
+  
+  /** Whether to split thread messages per test case */
+  splitThreadMessagePerTest: boolean;
 }
 
 /**
@@ -113,23 +116,48 @@ export function buildMainMessage(options: MessageBuilderOptions): string {
 }
 
 /**
- * Builds the thread detail message for bot thread mode
+ * Builds thread detail messages for bot thread mode
+ * Returns an array of messages - either one combined message or one per test
  * 
  * @param options - Message building options
- * @returns The formatted thread message text, or undefined if no details to show
+ * @returns Array of formatted thread messages, or undefined if no details to show
  */
-export function buildThreadDetailMessage(options: MessageBuilderOptions): string | undefined {
+export function buildThreadDetailMessages(options: MessageBuilderOptions): string[] | undefined {
   const {
     failures,
     maxFailures,
     maxDetailLines,
     maxDetailChars,
     showErrorDetails,
+    splitThreadMessagePerTest,
   } = options;
 
   if (!showErrorDetails || failures.length === 0) {
     return undefined;
   }
+
+  if (splitThreadMessagePerTest) {
+    return buildThreadDetailMessagesPerTest(options);
+  }
+
+  // Single combined message (original behavior)
+  const singleMessage = buildThreadDetailMessageCombined(options);
+  return singleMessage ? [singleMessage] : undefined;
+}
+
+/**
+ * Builds a single combined thread message with all errors (original behavior)
+ * 
+ * @param options - Message building options
+ * @returns The formatted thread message text, or undefined if no details to show
+ */
+function buildThreadDetailMessageCombined(options: MessageBuilderOptions): string | undefined {
+  const {
+    failures,
+    maxFailures,
+    maxDetailLines,
+    maxDetailChars,
+  } = options;
 
   const detailLines: string[] = [];
 
@@ -156,7 +184,50 @@ export function buildThreadDetailMessage(options: MessageBuilderOptions): string
     detailLines.push(`...and ${failures.length - maxFailures} more`);
   }
 
-  return detailLines.join('\n');
+  return detailLines.length > 0 ? detailLines.join('\n') : undefined;
+}
+
+/**
+ * Builds separate thread messages for each test failure
+ * 
+ * @param options - Message building options
+ * @returns Array of formatted thread messages, one per test failure
+ */
+function buildThreadDetailMessagesPerTest(options: MessageBuilderOptions): string[] | undefined {
+  const {
+    failures,
+    maxFailures,
+    maxDetailLines,
+    maxDetailChars,
+  } = options;
+
+  const messages: string[] = [];
+
+  for (const failure of failures.slice(0, maxFailures)) {
+    const messageLines: string[] = [];
+
+    // Test name and location
+    const where = [failure.project, failure.location].filter(Boolean).join(' ');
+    messageLines.push(`**${failure.title}**${where ? ` (${where})` : ''}`);
+
+    // Error details with full stack trace
+    if (failure.error) {
+      const details = formatErrorDetails(failure.error, maxDetailLines, maxDetailChars);
+      if (details) {
+        messageLines.push('```');
+        messageLines.push(details);
+        messageLines.push('```');
+      }
+    }
+
+    messages.push(messageLines.join('\n'));
+  }
+
+  if (failures.length > maxFailures) {
+    messages.push(`...and ${failures.length - maxFailures} more test failures not shown`);
+  }
+
+  return messages.length > 0 ? messages : undefined;
 }
 
 /**
@@ -167,7 +238,7 @@ export function buildThreadDetailMessage(options: MessageBuilderOptions): string
  * @param failedCount - Number of failed tests
  * @param failures - List of test failures
  * @param config - Message configuration options
- * @returns Object containing main message and optional thread message
+ * @returns Object containing main message and optional thread messages array
  */
 export function buildMessages(
   result: FullResult,
@@ -180,8 +251,9 @@ export function buildMessages(
     maxDetailChars: number;
     showErrorDetails: boolean;
     useBotThreadMode: boolean;
+    splitThreadMessagePerTest: boolean;
   }
-): { mainMessage: string; threadMessage?: string } {
+): { mainMessage: string; threadMessages?: string[] } {
   const options: MessageBuilderOptions = {
     resultStatus: result.status,
     passedCount,
@@ -192,10 +264,11 @@ export function buildMessages(
     maxDetailChars: config.maxDetailChars,
     showErrorDetails: config.showErrorDetails,
     useBotThreadMode: config.useBotThreadMode,
+    splitThreadMessagePerTest: config.splitThreadMessagePerTest,
   };
 
   const mainMessage = buildMainMessage(options);
-  const threadMessage = config.useBotThreadMode ? buildThreadDetailMessage(options) : undefined;
+  const threadMessages = config.useBotThreadMode ? buildThreadDetailMessages(options) : undefined;
 
-  return { mainMessage, threadMessage };
+  return { mainMessage, threadMessages };
 }

--- a/src/notificationSender.ts
+++ b/src/notificationSender.ts
@@ -24,7 +24,7 @@ import { validateWebhookUrl } from './utils.ts';
  * 
  * @param config - Reporter configuration
  * @param mainMessage - The main message text to send
- * @param threadMessage - Optional thread message (only used in bot thread mode)
+ * @param threadMessages - Optional array of thread messages (only used in bot thread mode)
  * @throws {SlackApiError} If the Slack API returns an error
  * @throws {NetworkError} If there's a network issue
  * @throws {ValidationError} If the webhook URL is invalid
@@ -32,12 +32,12 @@ import { validateWebhookUrl } from './utils.ts';
 export async function sendNotification(
   config: ReporterConfig,
   mainMessage: string,
-  threadMessage?: string,
+  threadMessages?: string[],
 ): Promise<void> {
   try {
     // Bot thread mode: send main message, then thread details
     if (config.canUseBotThread && config.botToken && config.botChannel) {
-      await sendViaBotWithThread(config, mainMessage, threadMessage);
+      await sendViaBotWithThread(config, mainMessage, threadMessages);
       return;
     }
 
@@ -52,15 +52,16 @@ export async function sendNotification(
 
 /**
  * Sends notification via Slack Bot with optional thread posting
+ * Supports sending multiple thread messages sequentially
  * 
  * @param config - Reporter configuration
  * @param mainMessage - The main message text
- * @param threadMessage - Optional thread message
+ * @param threadMessages - Optional array of thread messages
  */
 async function sendViaBotWithThread(
   config: ReporterConfig,
   mainMessage: string,
-  threadMessage?: string,
+  threadMessages?: string[],
 ): Promise<void> {
   if (!config.botToken || !config.botChannel) {
     throw new Error('Bot token and channel are required for bot thread mode');
@@ -81,20 +82,22 @@ async function sendViaBotWithThread(
   );
 
   // Send thread details if available
-  if (threadMessage && mainResponse.ts) {
-    await sendSlackBotMessage(
-      config.botToken,
-      {
-        channel: config.botChannel,
-        text: threadMessage,
-        threadTs: mainResponse.ts,
-      },
-      {
-        timeoutMs: config.timeoutMs,
-        retries: config.retries,
-        retryDelayMs: config.retryDelayMs,
-      },
-    );
+  if (threadMessages && threadMessages.length > 0 && mainResponse.ts) {
+    for (const threadMessage of threadMessages) {
+      await sendSlackBotMessage(
+        config.botToken,
+        {
+          channel: config.botChannel,
+          text: threadMessage,
+          threadTs: mainResponse.ts,
+        },
+        {
+          timeoutMs: config.timeoutMs,
+          retries: config.retries,
+          retryDelayMs: config.retryDelayMs,
+        },
+      );
+    }
   }
 }
 

--- a/src/notificationSender.ts
+++ b/src/notificationSender.ts
@@ -1,0 +1,133 @@
+/**
+ * Notification sending logic for Slack
+ * 
+ * This module handles the actual sending of messages to Slack via either:
+ * - Bot Token mode (with optional thread support)
+ * - Webhook mode (inline messages only)
+ */
+
+import type { ReporterConfig } from './reporterConfig.ts';
+import { sendSlackBotMessage } from './slackBotClient.ts';
+import { sendSlackWebhook } from './slackClient.ts';
+import type { SlackWebhookPayload } from './types.ts';
+import { validateWebhookUrl } from './utils.ts';
+
+/**
+ * Sends a Slack notification using the appropriate method based on configuration
+ * 
+ * This function automatically determines whether to use:
+ * - Bot Token mode with thread posting (if config.canUseBotThread is true)
+ * - Webhook mode with inline details (fallback)
+ * 
+ * Note: When both bot token and webhook URL are configured, bot thread mode takes
+ * precedence if errorDetailsInThread is enabled.
+ * 
+ * @param config - Reporter configuration
+ * @param mainMessage - The main message text to send
+ * @param threadMessage - Optional thread message (only used in bot thread mode)
+ * @throws {SlackApiError} If the Slack API returns an error
+ * @throws {NetworkError} If there's a network issue
+ * @throws {ValidationError} If the webhook URL is invalid
+ */
+export async function sendNotification(
+  config: ReporterConfig,
+  mainMessage: string,
+  threadMessage?: string,
+): Promise<void> {
+  try {
+    // Bot thread mode: send main message, then thread details
+    if (config.canUseBotThread && config.botToken && config.botChannel) {
+      await sendViaBotWithThread(config, mainMessage, threadMessage);
+      return;
+    }
+
+    // Webhook mode: send inline message
+    await sendViaWebhook(config, mainMessage);
+  } catch (err) {
+    console.warn('PlaywrightSlackReporter: failed to send notification');
+    console.warn(err);
+    throw err;
+  }
+}
+
+/**
+ * Sends notification via Slack Bot with optional thread posting
+ * 
+ * @param config - Reporter configuration
+ * @param mainMessage - The main message text
+ * @param threadMessage - Optional thread message
+ */
+async function sendViaBotWithThread(
+  config: ReporterConfig,
+  mainMessage: string,
+  threadMessage?: string,
+): Promise<void> {
+  if (!config.botToken || !config.botChannel) {
+    throw new Error('Bot token and channel are required for bot thread mode');
+  }
+
+  // Send main message
+  const mainResponse = await sendSlackBotMessage(
+    config.botToken,
+    {
+      channel: config.botChannel,
+      text: mainMessage,
+    },
+    {
+      timeoutMs: config.timeoutMs,
+      retries: config.retries,
+      retryDelayMs: config.retryDelayMs,
+    },
+  );
+
+  // Send thread details if available
+  if (threadMessage && mainResponse.ts) {
+    await sendSlackBotMessage(
+      config.botToken,
+      {
+        channel: config.botChannel,
+        text: threadMessage,
+        threadTs: mainResponse.ts,
+      },
+      {
+        timeoutMs: config.timeoutMs,
+        retries: config.retries,
+        retryDelayMs: config.retryDelayMs,
+      },
+    );
+  }
+}
+
+/**
+ * Sends notification via Slack Webhook
+ * 
+ * @param config - Reporter configuration
+ * @param message - The message text to send
+ */
+async function sendViaWebhook(config: ReporterConfig, message: string): Promise<void> {
+  const webhookUrl = config.getWebhookUrl();
+  
+  if (!webhookUrl) {
+    // No webhook URL configured, silently skip
+    return;
+  }
+
+  try {
+    validateWebhookUrl(webhookUrl);
+  } catch (err) {
+    console.warn('PlaywrightSlackReporter: invalid SLACK_WEBHOOK_URL');
+    console.warn(err);
+    return;
+  }
+
+  const payload: SlackWebhookPayload = {
+    text: message,
+    channel: config.channel,
+  };
+
+  await sendSlackWebhook(webhookUrl, payload, {
+    timeoutMs: config.timeoutMs,
+    retries: config.retries,
+    retryDelayMs: config.retryDelayMs,
+  });
+}

--- a/src/pathUtils.ts
+++ b/src/pathUtils.ts
@@ -1,0 +1,56 @@
+/**
+ * Utility functions for working with file paths
+ */
+
+/**
+ * Converts an absolute path to a relative path from the current working directory.
+ * If the path is not under the current working directory, returns the original path.
+ * 
+ * @param absolutePath - The absolute file path to convert
+ * @returns The relative path or the original path if not under cwd
+ * 
+ * @example
+ * // If cwd is /Users/user/project
+ * toRelativePath('/Users/user/project/src/file.ts') // Returns 'src/file.ts'
+ * toRelativePath('/other/path/file.ts') // Returns '/other/path/file.ts'
+ */
+export function toRelativePath(absolutePath: string): string {
+  const cwd = process.cwd();
+  if (absolutePath.startsWith(cwd)) {
+    const relative = absolutePath.slice(cwd.length);
+    // Remove leading slash if present
+    return relative.startsWith('/') ? relative.slice(1) : relative;
+  }
+  return absolutePath;
+}
+
+/**
+ * Escapes special regex characters in a string to make it safe for use in a RegExp.
+ * 
+ * @param str - The string to escape
+ * @returns The escaped string safe for RegExp
+ * 
+ * @example
+ * escapeRegex('/path/to/file') // Returns '\\/path\\/to\\/file'
+ */
+function escapeRegex(str: string): string {
+  return str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+/**
+ * Converts all absolute paths in stack traces and error messages to relative paths.
+ * This makes error messages more portable and easier to read.
+ * 
+ * @param text - The text containing absolute paths (e.g., stack trace)
+ * @returns The text with absolute paths replaced with relative paths (using '.' as the base)
+ * 
+ * @example
+ * // If cwd is /Users/user/project
+ * const stack = 'Error at /Users/user/project/src/file.ts:10:5'
+ * convertStackTraceToRelativePaths(stack) // Returns 'Error at ./src/file.ts:10:5'
+ */
+export function convertStackTraceToRelativePaths(text: string): string {
+  const cwd = process.cwd();
+  const escapedCwd = escapeRegex(cwd);
+  return text.replace(new RegExp(escapedCwd, 'g'), '.');
+}

--- a/src/playwrightReporter.ts
+++ b/src/playwrightReporter.ts
@@ -23,7 +23,8 @@ export interface PlaywrightSlackReporterOptions {
 }
 
 type Failure = {
-  title: string;
+  title: string;           
+  testName: string;        
   project?: string;
   location?: string;
   error?: string;
@@ -41,6 +42,14 @@ function toRelativePath(absolutePath: string): string {
     return relative.startsWith('/') ? relative.slice(1) : relative;
   }
   return absolutePath;
+}
+
+// Replace absolute paths in stack traces and code snippets
+// Pattern: matches common file path patterns in stack traces
+// TODO: ここは簡単にできそう
+function convertStackTraceToRelativePaths(text: string): string {
+  const cwd = process.cwd();
+  return text.replace(new RegExp(cwd.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'), 'g'), '.');
 }
 
 function formatErrorSummary(error?: string): string | undefined {
@@ -62,16 +71,14 @@ function formatErrorSummary(error?: string): string | undefined {
   return summary.length > 0 ? summary : lines[0];
 }
 
-function formatErrorSummaryForThread(error?: string): string {
-  const summary = formatErrorSummary(error);
-  return summary ?? 'Unknown error';
-}
-
 function formatErrorDetails(error: string, maxLines: number, maxChars: number): string | undefined {
   const cleaned = stripAnsi(error).replace(/\r/g, '').trim();
   if (!cleaned) return undefined;
 
-  const lines = cleaned.split('\n');
+  // Convert absolute paths to relative paths in stack traces
+  const withRelativePaths = convertStackTraceToRelativePaths(cleaned);
+
+  const lines = withRelativePaths.split('\n');
   const sliced = lines.slice(0, maxLines);
   const truncatedByLines = lines.length > maxLines;
   const joined = sliced.join('\n');
@@ -94,6 +101,8 @@ function resolveNotifyMode(optionsMode?: PlaywrightSlackNotifyMode): PlaywrightS
 
 export class PlaywrightSlackReporter implements Reporter {
   private readonly failures: Failure[] = [];
+  private passedCount = 0;
+  private failedCount = 0;
 
   private readonly options: Required<
     Pick<PlaywrightSlackReporterOptions, 'maxFailures' | 'maxDetailLines' | 'maxDetailChars' | 'timeoutMs' | 'retries' | 'retryDelayMs'>
@@ -108,8 +117,8 @@ export class PlaywrightSlackReporter implements Reporter {
       botToken: options.botToken,
       botChannel: options.botChannel,
       maxFailures: options.maxFailures ?? 5,
-      maxDetailLines: options.maxDetailLines ?? 40,
-      maxDetailChars: options.maxDetailChars ?? 2500,
+      maxDetailLines: options.maxDetailLines ?? 80,
+      maxDetailChars: options.maxDetailChars ?? 4000,
       timeoutMs: options.timeoutMs ?? 10_000,
       retries: options.retries ?? 2,
       retryDelayMs: options.retryDelayMs ?? 500,
@@ -118,16 +127,28 @@ export class PlaywrightSlackReporter implements Reporter {
   }
 
   onTestEnd(test: TestCase, result: TestResult): void {
-    if (result.status !== 'failed' && result.status !== 'timedOut') return;
+    if (result.status === 'failed' || result.status === 'timedOut') {
+      this.failedCount++;
+      
+      const titlePath = test.titlePath();
+      const title = titlePath.join(' › ');
+      // Extract only the test name (last element of titlePath)
+      const testName = titlePath[titlePath.length - 1] ?? title;
+      
+      const project = test.parent.project()?.name;
+      const location = test.location
+        ? `${toRelativePath(test.location.file)}:${test.location.line}:${test.location.column}`
+        : undefined;
+      const snippetSection = result.error?.snippet ? `\nCode snippet:\n${result.error.snippet}` : '';
+      const error = (result.error?.stack ?? result.error?.message)
+        ? `${result.error?.stack ?? result.error?.message}${snippetSection}`
+        : undefined;
 
-    const title = test.titlePath().join(' › ');
-    const project = test.parent.project()?.name;
-    const location = test.location
-      ? `${toRelativePath(test.location.file)}:${test.location.line}:${test.location.column}`
-      : undefined;
-    const error = result.error?.message;
 
-    this.failures.push({ title, project, location, error });
+      this.failures.push({ title, testName, project, location, error });
+    } else if (result.status === 'passed') {
+      this.passedCount++;
+    }
   }
 
   async onEnd(result: FullResult): Promise<void> {
@@ -143,7 +164,8 @@ export class PlaywrightSlackReporter implements Reporter {
       console.warn('PlaywrightSlackReporter: errorDetailsInThread is enabled but Slack Bot config is missing. Set botToken/botChannel or SLACK_BOT_TOKEN/SLACK_BOT_CHANNEL_ID. Falling back to webhook inline details.');
     }
 
-    const header = `Playwright E2E result: ${result.status} (failures: ${this.failures.length})`;
+    const header = `Playwright E2E result: ${result.status}`;
+    const testSummary = `:large_green_circle: Passed: ${this.passedCount} :red_circle: Failed: ${this.failedCount}`;
 
     const repo = process.env.GITHUB_REPOSITORY;
     const sha = process.env.GITHUB_SHA;
@@ -153,7 +175,7 @@ export class PlaywrightSlackReporter implements Reporter {
     const runUrl =
       repo && runId && serverUrl ? `${serverUrl}/${repo}/actions/runs/${runId}` : undefined;
 
-    const lines: string[] = [header];
+    const lines: string[] = [header, testSummary];
     if (repo) lines.push(`repo: ${repo}`);
     if (sha) lines.push(`sha: ${sha}`);
     if (runUrl) lines.push(`run: ${runUrl}`);
@@ -161,21 +183,24 @@ export class PlaywrightSlackReporter implements Reporter {
     if (this.failures.length > 0) {
       lines.push('failures:');
       for (const failure of this.failures.slice(0, this.options.maxFailures)) {
-        const where = [failure.project, failure.location].filter(Boolean).join(' ');
-        lines.push(`- ${failure.title}${where ? ` (${where})` : ''}`);
+        if (canUseBotThread) {
+          lines.push(`:red_circle: ${failure.testName}`);
+        } else {
+          const where = [failure.project, failure.location].filter(Boolean).join(' ');
+          lines.push(`:red_circle: ${failure.title}${where ? ` (${where})` : ''}`);
 
-
-        if (this.options.showErrorDetails && !canUseBotThread && failure.error) {
-          const details = formatErrorDetails(
-            failure.error,
-            this.options.maxDetailLines,
-            this.options.maxDetailChars,
-          );
-          if (details) {
-            lines.push('  details:');
-            lines.push('```');
-            lines.push(details);
-            lines.push('```');
+          if (this.options.showErrorDetails && failure.error) {
+            const details = formatErrorDetails(
+              failure.error,
+              this.options.maxDetailLines,
+              this.options.maxDetailChars,
+            );
+            if (details) {
+              lines.push('  details:');
+              lines.push('```');
+              lines.push(details);
+              lines.push('```');
+            }
           }
         }
       }
@@ -190,6 +215,7 @@ export class PlaywrightSlackReporter implements Reporter {
     };
 
     try {
+      // TODO: READMEにenvにbot_tokenとwebhoo_urlどちらも設定してある場合は、thread方式になることを明記するべき
       if (canUseBotThread && botToken && botChannel) {
         const summary = await sendSlackBotMessage(
           botToken,
@@ -205,11 +231,29 @@ export class PlaywrightSlackReporter implements Reporter {
         );
 
         if (this.options.showErrorDetails && this.failures.length > 0 && summary.ts) {
-        const detailLines: string[] = ['Failed test error reasons:'];
+        const detailLines: string[] = [];
 
         for (const failure of this.failures.slice(0, this.options.maxFailures)) {
-          const errorSummary = formatErrorSummaryForThread(failure.error);
-          detailLines.push(`- ${errorSummary}`);
+          // Test name and location
+          const where = [failure.project, failure.location].filter(Boolean).join(' ');
+          detailLines.push(`**${failure.title}**${where ? ` (${where})` : ''}`);
+          
+          // Error details with full stack trace
+          if (failure.error) {
+            const details = formatErrorDetails(
+              failure.error,
+              this.options.maxDetailLines,
+              this.options.maxDetailChars,
+            );
+            if (details) {
+              detailLines.push('```');
+              detailLines.push(details);
+              detailLines.push('```');
+            }
+          }
+          
+          // Separator between errors (empty line)
+          detailLines.push('');
         }
 
         if (this.failures.length > this.options.maxFailures) {

--- a/src/playwrightReporter.ts
+++ b/src/playwrightReporter.ts
@@ -89,7 +89,7 @@ export class PlaywrightSlackReporter implements Reporter {
 
     try {
       // Build messages
-      const { mainMessage, threadMessage } = buildMessages(
+      const { mainMessage, threadMessages } = buildMessages(
         result,
         this.passedCount,
         this.failedCount,
@@ -100,11 +100,12 @@ export class PlaywrightSlackReporter implements Reporter {
           maxDetailChars: this.config.maxDetailChars,
           showErrorDetails: this.config.showErrorDetails,
           useBotThreadMode: this.config.canUseBotThread,
+          splitThreadMessagePerTest: this.config.splitThreadMessagePerTest,
         }
       );
 
       // Send notification
-      await sendNotification(this.config, mainMessage, threadMessage);
+      await sendNotification(this.config, mainMessage, threadMessages);
     } catch (err) {
       // Error already logged by sendNotification, just swallow it here
       // to prevent Playwright from failing due to reporter errors

--- a/src/playwrightReporter.ts
+++ b/src/playwrightReporter.ts
@@ -1,5 +1,8 @@
 import type { FullResult, Reporter, TestCase, TestResult } from '@playwright/test/reporter';
 
+import { DEFAULTS, EMOJIS, ENV_VARS } from './constants.ts';
+import { formatErrorDetails } from './formatters.ts';
+import { toRelativePath } from './pathUtils.ts';
 import { sendSlackBotMessage } from './slackBotClient.ts';
 import { sendSlackWebhook } from './slackClient.ts';
 import type { SlackWebhookPayload } from './types.ts';
@@ -30,73 +33,10 @@ type Failure = {
   error?: string;
 };
 
-function stripAnsi(text: string): string {
-  return text.replace(/\u001b\[[0-9;]*m/g, '').replace(/\x1b\[[0-9;]*m/g, '');
-}
-
-function toRelativePath(absolutePath: string): string {
-  const cwd = process.cwd();
-  if (absolutePath.startsWith(cwd)) {
-    const relative = absolutePath.slice(cwd.length);
-    // Remove leading slash if present
-    return relative.startsWith('/') ? relative.slice(1) : relative;
-  }
-  return absolutePath;
-}
-
-// Replace absolute paths in stack traces and code snippets
-// Pattern: matches common file path patterns in stack traces
-// TODO: ここは簡単にできそう
-function convertStackTraceToRelativePaths(text: string): string {
-  const cwd = process.cwd();
-  return text.replace(new RegExp(cwd.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'), 'g'), '.');
-}
-
-function formatErrorSummary(error?: string): string | undefined {
-  if (!error) return undefined;
-
-  const cleaned = stripAnsi(error).replace(/\r/g, '');
-  const lines = cleaned
-    .split('\n')
-    .map((line) => line.trim())
-    .filter((line) => line.length > 0);
-
-  if (lines.length === 0) return undefined;
-
-  const summary = lines
-    .filter((line) => !line.startsWith('at '))
-    .slice(0, 3)
-    .join(' | ');
-
-  return summary.length > 0 ? summary : lines[0];
-}
-
-function formatErrorDetails(error: string, maxLines: number, maxChars: number): string | undefined {
-  const cleaned = stripAnsi(error).replace(/\r/g, '').trim();
-  if (!cleaned) return undefined;
-
-  // Convert absolute paths to relative paths in stack traces
-  const withRelativePaths = convertStackTraceToRelativePaths(cleaned);
-
-  const lines = withRelativePaths.split('\n');
-  const sliced = lines.slice(0, maxLines);
-  const truncatedByLines = lines.length > maxLines;
-  const joined = sliced.join('\n');
-
-  const truncatedByChars = joined.length > maxChars;
-  const detail = truncatedByChars ? `${joined.slice(0, maxChars)}\n...(truncated)` : joined;
-
-  if (truncatedByLines && !truncatedByChars) {
-    return `${detail}\n...(truncated)`;
-  }
-
-  return detail;
-}
-
 function resolveNotifyMode(optionsMode?: PlaywrightSlackNotifyMode): PlaywrightSlackNotifyMode {
-  const envMode = (process.env.PLAYWRIGHT_SLACK_NOTIFY ?? '').toLowerCase();
+  const envMode = (process.env[ENV_VARS.PLAYWRIGHT_SLACK_NOTIFY] ?? '').toLowerCase();
   if (envMode === 'always' || envMode === 'failure') return envMode;
-  return optionsMode ?? 'failure';
+  return optionsMode ?? DEFAULTS.NOTIFY_MODE;
 }
 
 export class PlaywrightSlackReporter implements Reporter {
@@ -112,16 +52,16 @@ export class PlaywrightSlackReporter implements Reporter {
   constructor(options: PlaywrightSlackReporterOptions = {}) {
     this.options = {
       notifyMode: options.notifyMode,
-      showErrorDetails: options.showErrorDetails ?? true,
-      errorDetailsInThread: options.errorDetailsInThread ?? false,
+      showErrorDetails: options.showErrorDetails ?? DEFAULTS.SHOW_ERROR_DETAILS,
+      errorDetailsInThread: options.errorDetailsInThread ?? DEFAULTS.ERROR_DETAILS_IN_THREAD,
       botToken: options.botToken,
       botChannel: options.botChannel,
-      maxFailures: options.maxFailures ?? 5,
-      maxDetailLines: options.maxDetailLines ?? 80,
-      maxDetailChars: options.maxDetailChars ?? 4000,
-      timeoutMs: options.timeoutMs ?? 10_000,
-      retries: options.retries ?? 2,
-      retryDelayMs: options.retryDelayMs ?? 500,
+      maxFailures: options.maxFailures ?? DEFAULTS.MAX_FAILURES,
+      maxDetailLines: options.maxDetailLines ?? DEFAULTS.MAX_DETAIL_LINES,
+      maxDetailChars: options.maxDetailChars ?? DEFAULTS.MAX_DETAIL_CHARS,
+      timeoutMs: options.timeoutMs ?? DEFAULTS.TIMEOUT_MS,
+      retries: options.retries ?? DEFAULTS.RETRIES,
+      retryDelayMs: options.retryDelayMs ?? DEFAULTS.RETRY_DELAY_MS,
       channel: options.channel,
     };
   }
@@ -156,8 +96,8 @@ export class PlaywrightSlackReporter implements Reporter {
     const shouldNotify = notifyMode === 'always' ? true : this.failures.length > 0 || result.status !== 'passed';
     if (!shouldNotify) return;
 
-    const botToken = (this.options.botToken ?? process.env.SLACK_BOT_TOKEN)?.trim();
-    const botChannel = (this.options.botChannel ?? process.env.SLACK_BOT_CHANNEL_ID ?? this.options.channel)?.trim();
+    const botToken = (this.options.botToken ?? process.env[ENV_VARS.SLACK_BOT_TOKEN])?.trim();
+    const botChannel = (this.options.botChannel ?? process.env[ENV_VARS.SLACK_BOT_CHANNEL_ID] ?? this.options.channel)?.trim();
     const canUseBotThread = this.options.errorDetailsInThread && !!botToken && !!botChannel;
 
     if (this.options.errorDetailsInThread && !canUseBotThread) {
@@ -165,12 +105,12 @@ export class PlaywrightSlackReporter implements Reporter {
     }
 
     const header = `Playwright E2E result: ${result.status}`;
-    const testSummary = `:large_green_circle: Passed: ${this.passedCount} :red_circle: Failed: ${this.failedCount}`;
+    const testSummary = `${EMOJIS.GREEN_CIRCLE} Passed: ${this.passedCount} ${EMOJIS.RED_CIRCLE} Failed: ${this.failedCount}`;
 
-    const repo = process.env.GITHUB_REPOSITORY;
-    const sha = process.env.GITHUB_SHA;
-    const runId = process.env.GITHUB_RUN_ID;
-    const serverUrl = process.env.GITHUB_SERVER_URL;
+    const repo = process.env[ENV_VARS.GITHUB_REPOSITORY];
+    const sha = process.env[ENV_VARS.GITHUB_SHA];
+    const runId = process.env[ENV_VARS.GITHUB_RUN_ID];
+    const serverUrl = process.env[ENV_VARS.GITHUB_SERVER_URL];
 
     const runUrl =
       repo && runId && serverUrl ? `${serverUrl}/${repo}/actions/runs/${runId}` : undefined;
@@ -184,10 +124,10 @@ export class PlaywrightSlackReporter implements Reporter {
       lines.push('failures:');
       for (const failure of this.failures.slice(0, this.options.maxFailures)) {
         if (canUseBotThread) {
-          lines.push(`:red_circle: ${failure.testName}`);
+          lines.push(`${EMOJIS.RED_CIRCLE} ${failure.testName}`);
         } else {
           const where = [failure.project, failure.location].filter(Boolean).join(' ');
-          lines.push(`:red_circle: ${failure.title}${where ? ` (${where})` : ''}`);
+          lines.push(`${EMOJIS.RED_CIRCLE} ${failure.title}${where ? ` (${where})` : ''}`);
 
           if (this.options.showErrorDetails && failure.error) {
             const details = formatErrorDetails(
@@ -282,7 +222,7 @@ export class PlaywrightSlackReporter implements Reporter {
         return;
       }
 
-      const webhookUrl = process.env.SLACK_WEBHOOK_URL;
+      const webhookUrl = process.env[ENV_VARS.SLACK_WEBHOOK_URL];
       if (!webhookUrl || webhookUrl.trim().length === 0) return;
 
       try {

--- a/src/playwrightReporter.ts
+++ b/src/playwrightReporter.ts
@@ -64,11 +64,17 @@ export class PlaywrightSlackReporter implements Reporter {
         ? `${toRelativePath(test.location.file)}:${test.location.line}:${test.location.column}`
         : undefined;
       
-      // Combine error stack/message with snippet if available
-      const snippetSection = result.error?.snippet ? `\nCode snippet:\n${result.error.snippet}` : '';
-      const error = (result.error?.stack ?? result.error?.message)
-        ? `${result.error?.stack ?? result.error?.message}${snippetSection}`
+      const allErrors = result.errors && result.errors.length > 0
+        ? result.errors
+            .map(e => e.stack ?? e.message)
+            .filter(Boolean)
+            .join('\n\n---\n\n')
         : undefined;
+
+      const errorText = allErrors ?? result.error?.stack ?? result.error?.message;
+
+      const snippetSection = result.error?.snippet ? `\nCode snippet:\n${result.error.snippet}` : '';
+      const error = errorText ? `${errorText}${snippetSection}` : undefined;
 
       this.failures.push({ title, testName, project, location, error });
     } else if (result.status === 'passed') {

--- a/src/playwrightReporter.ts
+++ b/src/playwrightReporter.ts
@@ -1,71 +1,55 @@
 import type { FullResult, Reporter, TestCase, TestResult } from '@playwright/test/reporter';
 
-import { DEFAULTS, EMOJIS, ENV_VARS } from './constants.ts';
-import { formatErrorDetails } from './formatters.ts';
+import { buildMessages } from './messageBuilder.ts';
+import { sendNotification } from './notificationSender.ts';
 import { toRelativePath } from './pathUtils.ts';
-import { sendSlackBotMessage } from './slackBotClient.ts';
-import { sendSlackWebhook } from './slackClient.ts';
-import type { SlackWebhookPayload } from './types.ts';
-import { validateWebhookUrl } from './utils.ts';
+import { ReporterConfig } from './reporterConfig.ts';
+import type { Failure, PlaywrightSlackReporterOptions } from './reporterTypes.ts';
 
-export type PlaywrightSlackNotifyMode = 'failure' | 'always';
+// Re-export types for backward compatibility
+export type { PlaywrightSlackNotifyMode, PlaywrightSlackReporterOptions } from './reporterTypes.ts';
 
-export interface PlaywrightSlackReporterOptions {
-  notifyMode?: PlaywrightSlackNotifyMode;
-  showErrorDetails?: boolean;
-  errorDetailsInThread?: boolean;
-  botToken?: string;
-  botChannel?: string;
-  maxFailures?: number;
-  maxDetailLines?: number;
-  maxDetailChars?: number;
-  channel?: string;
-  timeoutMs?: number;
-  retries?: number;
-  retryDelayMs?: number;
-}
-
-type Failure = {
-  title: string;           
-  testName: string;        
-  project?: string;
-  location?: string;
-  error?: string;
-};
-
-function resolveNotifyMode(optionsMode?: PlaywrightSlackNotifyMode): PlaywrightSlackNotifyMode {
-  const envMode = (process.env[ENV_VARS.PLAYWRIGHT_SLACK_NOTIFY] ?? '').toLowerCase();
-  if (envMode === 'always' || envMode === 'failure') return envMode;
-  return optionsMode ?? DEFAULTS.NOTIFY_MODE;
-}
-
+/**
+ * Playwright reporter that sends test results to Slack
+ * 
+ * Supports two notification modes:
+ * 1. Webhook mode: Sends inline messages with full error details
+ * 2. Bot Token mode: Can post main message + error details in thread
+ * 
+ * @example
+ * // In playwright.config.ts
+ * export default defineConfig({
+ *   reporter: [
+ *     ['@sugityan/playwright-slack-notification/reporter', {
+ *       notifyMode: 'failure',
+ *       showErrorDetails: true,
+ *       errorDetailsInThread: true, // Requires bot token
+ *     }],
+ *   ],
+ * });
+ */
 export class PlaywrightSlackReporter implements Reporter {
+  private readonly config: ReporterConfig;
   private readonly failures: Failure[] = [];
   private passedCount = 0;
   private failedCount = 0;
 
-  private readonly options: Required<
-    Pick<PlaywrightSlackReporterOptions, 'maxFailures' | 'maxDetailLines' | 'maxDetailChars' | 'timeoutMs' | 'retries' | 'retryDelayMs'>
-  > &
-    Pick<PlaywrightSlackReporterOptions, 'channel' | 'notifyMode' | 'showErrorDetails' | 'errorDetailsInThread' | 'botToken' | 'botChannel'>;
-
+  /**
+   * Creates a new PlaywrightSlackReporter
+   * 
+   * @param options - Configuration options
+   */
   constructor(options: PlaywrightSlackReporterOptions = {}) {
-    this.options = {
-      notifyMode: options.notifyMode,
-      showErrorDetails: options.showErrorDetails ?? DEFAULTS.SHOW_ERROR_DETAILS,
-      errorDetailsInThread: options.errorDetailsInThread ?? DEFAULTS.ERROR_DETAILS_IN_THREAD,
-      botToken: options.botToken,
-      botChannel: options.botChannel,
-      maxFailures: options.maxFailures ?? DEFAULTS.MAX_FAILURES,
-      maxDetailLines: options.maxDetailLines ?? DEFAULTS.MAX_DETAIL_LINES,
-      maxDetailChars: options.maxDetailChars ?? DEFAULTS.MAX_DETAIL_CHARS,
-      timeoutMs: options.timeoutMs ?? DEFAULTS.TIMEOUT_MS,
-      retries: options.retries ?? DEFAULTS.RETRIES,
-      retryDelayMs: options.retryDelayMs ?? DEFAULTS.RETRY_DELAY_MS,
-      channel: options.channel,
-    };
+    this.config = new ReporterConfig(options);
   }
 
+  /**
+   * Called when a test ends
+   * Collects test results and failure information
+   * 
+   * @param test - The test case
+   * @param result - The test result
+   */
   onTestEnd(test: TestCase, result: TestResult): void {
     if (result.status === 'failed' || result.status === 'timedOut') {
       this.failedCount++;
@@ -79,11 +63,12 @@ export class PlaywrightSlackReporter implements Reporter {
       const location = test.location
         ? `${toRelativePath(test.location.file)}:${test.location.line}:${test.location.column}`
         : undefined;
+      
+      // Combine error stack/message with snippet if available
       const snippetSection = result.error?.snippet ? `\nCode snippet:\n${result.error.snippet}` : '';
       const error = (result.error?.stack ?? result.error?.message)
         ? `${result.error?.stack ?? result.error?.message}${snippetSection}`
         : undefined;
-
 
       this.failures.push({ title, testName, project, location, error });
     } else if (result.status === 'passed') {
@@ -91,156 +76,38 @@ export class PlaywrightSlackReporter implements Reporter {
     }
   }
 
+  /**
+   * Called when all tests have finished
+   * Sends notification to Slack if conditions are met
+   * 
+   * @param result - The full test result
+   */
   async onEnd(result: FullResult): Promise<void> {
-    const notifyMode = resolveNotifyMode(this.options.notifyMode);
-    const shouldNotify = notifyMode === 'always' ? true : this.failures.length > 0 || result.status !== 'passed';
+    // Check if we should send notification
+    const shouldNotify = this.config.shouldNotify(this.failures.length > 0, result.status);
     if (!shouldNotify) return;
 
-    const botToken = (this.options.botToken ?? process.env[ENV_VARS.SLACK_BOT_TOKEN])?.trim();
-    const botChannel = (this.options.botChannel ?? process.env[ENV_VARS.SLACK_BOT_CHANNEL_ID] ?? this.options.channel)?.trim();
-    const canUseBotThread = this.options.errorDetailsInThread && !!botToken && !!botChannel;
-
-    if (this.options.errorDetailsInThread && !canUseBotThread) {
-      console.warn('PlaywrightSlackReporter: errorDetailsInThread is enabled but Slack Bot config is missing. Set botToken/botChannel or SLACK_BOT_TOKEN/SLACK_BOT_CHANNEL_ID. Falling back to webhook inline details.');
-    }
-
-    const header = `Playwright E2E result: ${result.status}`;
-    const testSummary = `${EMOJIS.GREEN_CIRCLE} Passed: ${this.passedCount} ${EMOJIS.RED_CIRCLE} Failed: ${this.failedCount}`;
-
-    const repo = process.env[ENV_VARS.GITHUB_REPOSITORY];
-    const sha = process.env[ENV_VARS.GITHUB_SHA];
-    const runId = process.env[ENV_VARS.GITHUB_RUN_ID];
-    const serverUrl = process.env[ENV_VARS.GITHUB_SERVER_URL];
-
-    const runUrl =
-      repo && runId && serverUrl ? `${serverUrl}/${repo}/actions/runs/${runId}` : undefined;
-
-    const lines: string[] = [header, testSummary];
-    if (repo) lines.push(`repo: ${repo}`);
-    if (sha) lines.push(`sha: ${sha}`);
-    if (runUrl) lines.push(`run: ${runUrl}`);
-
-    if (this.failures.length > 0) {
-      lines.push('failures:');
-      for (const failure of this.failures.slice(0, this.options.maxFailures)) {
-        if (canUseBotThread) {
-          lines.push(`${EMOJIS.RED_CIRCLE} ${failure.testName}`);
-        } else {
-          const where = [failure.project, failure.location].filter(Boolean).join(' ');
-          lines.push(`${EMOJIS.RED_CIRCLE} ${failure.title}${where ? ` (${where})` : ''}`);
-
-          if (this.options.showErrorDetails && failure.error) {
-            const details = formatErrorDetails(
-              failure.error,
-              this.options.maxDetailLines,
-              this.options.maxDetailChars,
-            );
-            if (details) {
-              lines.push('  details:');
-              lines.push('```');
-              lines.push(details);
-              lines.push('```');
-            }
-          }
-        }
-      }
-      if (this.failures.length > this.options.maxFailures) {
-        lines.push(`...and ${this.failures.length - this.options.maxFailures} more`);
-      }
-    }
-
-    const payload: SlackWebhookPayload = {
-      text: lines.join('\n'),
-      channel: this.options.channel,
-    };
-
     try {
-      // TODO: READMEにenvにbot_tokenとwebhoo_urlどちらも設定してある場合は、thread方式になることを明記するべき
-      if (canUseBotThread && botToken && botChannel) {
-        const summary = await sendSlackBotMessage(
-          botToken,
-          {
-            channel: botChannel,
-            text: payload.text,
-          },
-          {
-            timeoutMs: this.options.timeoutMs,
-            retries: this.options.retries,
-            retryDelayMs: this.options.retryDelayMs,
-          },
-        );
-
-        if (this.options.showErrorDetails && this.failures.length > 0 && summary.ts) {
-        const detailLines: string[] = [];
-
-        for (const failure of this.failures.slice(0, this.options.maxFailures)) {
-          // Test name and location
-          const where = [failure.project, failure.location].filter(Boolean).join(' ');
-          detailLines.push(`**${failure.title}**${where ? ` (${where})` : ''}`);
-          
-          // Error details with full stack trace
-          if (failure.error) {
-            const details = formatErrorDetails(
-              failure.error,
-              this.options.maxDetailLines,
-              this.options.maxDetailChars,
-            );
-            if (details) {
-              detailLines.push('```');
-              detailLines.push(details);
-              detailLines.push('```');
-            }
-          }
-          
-          // Separator between errors (empty line)
-          detailLines.push('');
+      // Build messages
+      const { mainMessage, threadMessage } = buildMessages(
+        result,
+        this.passedCount,
+        this.failedCount,
+        this.failures,
+        {
+          maxFailures: this.config.maxFailures,
+          maxDetailLines: this.config.maxDetailLines,
+          maxDetailChars: this.config.maxDetailChars,
+          showErrorDetails: this.config.showErrorDetails,
+          useBotThreadMode: this.config.canUseBotThread,
         }
+      );
 
-        if (this.failures.length > this.options.maxFailures) {
-          detailLines.push(`...and ${this.failures.length - this.options.maxFailures} more`);
-        }
-
-        const detailPayload: SlackWebhookPayload = {
-          text: detailLines.join('\n'),
-          channel: botChannel,
-        };
-
-          await sendSlackBotMessage(
-            botToken,
-            {
-              channel: botChannel,
-              text: detailPayload.text,
-              threadTs: summary.ts,
-            },
-            {
-              timeoutMs: this.options.timeoutMs,
-              retries: this.options.retries,
-              retryDelayMs: this.options.retryDelayMs,
-            },
-          );
-        }
-        return;
-      }
-
-      const webhookUrl = process.env[ENV_VARS.SLACK_WEBHOOK_URL];
-      if (!webhookUrl || webhookUrl.trim().length === 0) return;
-
-      try {
-        validateWebhookUrl(webhookUrl);
-      } catch (err) {
-        console.warn('PlaywrightSlackReporter: invalid SLACK_WEBHOOK_URL');
-        console.warn(err);
-        return;
-      }
-
-      await sendSlackWebhook(webhookUrl, payload, {
-          timeoutMs: this.options.timeoutMs,
-          retries: this.options.retries,
-          retryDelayMs: this.options.retryDelayMs,
-        });
+      // Send notification
+      await sendNotification(this.config, mainMessage, threadMessage);
     } catch (err) {
-      console.warn('PlaywrightSlackReporter: failed to send notification');
-      console.warn(err);
+      // Error already logged by sendNotification, just swallow it here
+      // to prevent Playwright from failing due to reporter errors
     }
   }
 }

--- a/src/reporterConfig.ts
+++ b/src/reporterConfig.ts
@@ -1,0 +1,128 @@
+/**
+ * Configuration management for the Playwright Slack Reporter
+ */
+
+import { DEFAULTS, ENV_VARS } from './constants.ts';
+import type { PlaywrightSlackNotifyMode, PlaywrightSlackReporterOptions, ResolvedReporterOptions } from './reporterTypes.ts';
+
+/**
+ * Configuration class that manages reporter options and provides computed properties
+ */
+export class ReporterConfig {
+  readonly notifyMode?: PlaywrightSlackNotifyMode;
+  readonly showErrorDetails: boolean;
+  readonly errorDetailsInThread: boolean;
+  readonly maxFailures: number;
+  readonly maxDetailLines: number;
+  readonly maxDetailChars: number;
+  readonly timeoutMs: number;
+  readonly retries: number;
+  readonly retryDelayMs: number;
+  readonly channel?: string;
+  
+  // Computed properties for Slack configuration
+  readonly botToken?: string;
+  readonly botChannel?: string;
+  readonly canUseBotThread: boolean;
+
+  /**
+   * Creates a new ReporterConfig instance with defaults applied
+   * 
+   * @param options - User-provided configuration options
+   */
+  constructor(options: PlaywrightSlackReporterOptions = {}) {
+    // Apply defaults
+    this.notifyMode = options.notifyMode;
+    this.showErrorDetails = options.showErrorDetails ?? DEFAULTS.SHOW_ERROR_DETAILS;
+    this.errorDetailsInThread = options.errorDetailsInThread ?? DEFAULTS.ERROR_DETAILS_IN_THREAD;
+    this.maxFailures = options.maxFailures ?? DEFAULTS.MAX_FAILURES;
+    this.maxDetailLines = options.maxDetailLines ?? DEFAULTS.MAX_DETAIL_LINES;
+    this.maxDetailChars = options.maxDetailChars ?? DEFAULTS.MAX_DETAIL_CHARS;
+    this.timeoutMs = options.timeoutMs ?? DEFAULTS.TIMEOUT_MS;
+    this.retries = options.retries ?? DEFAULTS.RETRIES;
+    this.retryDelayMs = options.retryDelayMs ?? DEFAULTS.RETRY_DELAY_MS;
+    this.channel = options.channel;
+
+    // Resolve bot configuration from options or environment
+    this.botToken = (options.botToken ?? process.env[ENV_VARS.SLACK_BOT_TOKEN])?.trim();
+    this.botChannel = (options.botChannel ?? process.env[ENV_VARS.SLACK_BOT_CHANNEL_ID] ?? this.channel)?.trim();
+    
+    // Compute whether bot thread mode is available
+    this.canUseBotThread = this.errorDetailsInThread && !!this.botToken && !!this.botChannel;
+
+    // Warn if thread mode is requested but not available
+    if (this.errorDetailsInThread && !this.canUseBotThread) {
+      console.warn(
+        'PlaywrightSlackReporter: errorDetailsInThread is enabled but Slack Bot config is missing. ' +
+        'Set botToken/botChannel or SLACK_BOT_TOKEN/SLACK_BOT_CHANNEL_ID. ' +
+        'Falling back to webhook inline details.'
+      );
+    }
+  }
+
+  /**
+   * Resolves the notify mode from options or environment variable
+   * 
+   * @param optionsMode - The mode specified in options
+   * @returns The resolved notify mode
+   */
+  static resolveNotifyMode(optionsMode?: PlaywrightSlackNotifyMode): PlaywrightSlackNotifyMode {
+    const envMode = (process.env[ENV_VARS.PLAYWRIGHT_SLACK_NOTIFY] ?? '').toLowerCase();
+    if (envMode === 'always' || envMode === 'failure') return envMode;
+    return optionsMode ?? DEFAULTS.NOTIFY_MODE;
+  }
+
+  /**
+   * Gets the resolved notify mode for this configuration
+   * 
+   * @returns The notify mode to use
+   */
+  getNotifyMode(): PlaywrightSlackNotifyMode {
+    return ReporterConfig.resolveNotifyMode(this.notifyMode);
+  }
+
+  /**
+   * Determines if a notification should be sent based on test results
+   * 
+   * @param hasFailures - Whether there are any test failures
+   * @param resultStatus - The overall test run status
+   * @returns true if notification should be sent
+   */
+  shouldNotify(hasFailures: boolean, resultStatus: string): boolean {
+    const mode = this.getNotifyMode();
+    if (mode === 'always') return true;
+    return hasFailures || resultStatus !== 'passed';
+  }
+
+  /**
+   * Gets the webhook URL from environment
+   * 
+   * @returns The webhook URL or undefined if not set
+   */
+  getWebhookUrl(): string | undefined {
+    const url = process.env[ENV_VARS.SLACK_WEBHOOK_URL];
+    return url && url.trim().length > 0 ? url : undefined;
+  }
+
+  /**
+   * Converts this config to a plain object matching ResolvedReporterOptions
+   * 
+   * @returns Plain object representation
+   */
+  toObject(): ResolvedReporterOptions {
+    return {
+      notifyMode: this.notifyMode,
+      showErrorDetails: this.showErrorDetails,
+      errorDetailsInThread: this.errorDetailsInThread,
+      botToken: this.botToken,
+      botChannel: this.botChannel,
+      maxFailures: this.maxFailures,
+      maxDetailLines: this.maxDetailLines,
+      maxDetailChars: this.maxDetailChars,
+      timeoutMs: this.timeoutMs,
+      retries: this.retries,
+      retryDelayMs: this.retryDelayMs,
+      channel: this.channel,
+    };
+  }
+}

--- a/src/reporterConfig.ts
+++ b/src/reporterConfig.ts
@@ -12,6 +12,7 @@ export class ReporterConfig {
   readonly notifyMode?: PlaywrightSlackNotifyMode;
   readonly showErrorDetails: boolean;
   readonly errorDetailsInThread: boolean;
+  readonly splitThreadMessagePerTest: boolean;
   readonly maxFailures: number;
   readonly maxDetailLines: number;
   readonly maxDetailChars: number;
@@ -35,6 +36,7 @@ export class ReporterConfig {
     this.notifyMode = options.notifyMode;
     this.showErrorDetails = options.showErrorDetails ?? DEFAULTS.SHOW_ERROR_DETAILS;
     this.errorDetailsInThread = options.errorDetailsInThread ?? DEFAULTS.ERROR_DETAILS_IN_THREAD;
+    this.splitThreadMessagePerTest = options.splitThreadMessagePerTest ?? DEFAULTS.SPLIT_THREAD_MESSAGE_PER_TEST;
     this.maxFailures = options.maxFailures ?? DEFAULTS.MAX_FAILURES;
     this.maxDetailLines = options.maxDetailLines ?? DEFAULTS.MAX_DETAIL_LINES;
     this.maxDetailChars = options.maxDetailChars ?? DEFAULTS.MAX_DETAIL_CHARS;
@@ -114,6 +116,7 @@ export class ReporterConfig {
       notifyMode: this.notifyMode,
       showErrorDetails: this.showErrorDetails,
       errorDetailsInThread: this.errorDetailsInThread,
+      splitThreadMessagePerTest: this.splitThreadMessagePerTest,
       botToken: this.botToken,
       botChannel: this.botChannel,
       maxFailures: this.maxFailures,

--- a/src/reporterTypes.ts
+++ b/src/reporterTypes.ts
@@ -1,0 +1,84 @@
+/**
+ * Type definitions for the Playwright Slack Reporter
+ */
+
+export type PlaywrightSlackNotifyMode = 'failure' | 'always';
+
+/**
+ * Configuration options for PlaywrightSlackReporter
+ */
+export interface PlaywrightSlackReporterOptions {
+  /** When to send notifications: 'failure' (default) or 'always' */
+  notifyMode?: PlaywrightSlackNotifyMode;
+  
+  /** Whether to show error details in messages (default: true) */
+  showErrorDetails?: boolean;
+  
+  /** Whether to post error details in a thread (requires Bot Token mode) */
+  errorDetailsInThread?: boolean;
+  
+  /** Slack Bot Token (alternative to webhook) */
+  botToken?: string;
+  
+  /** Slack Bot Channel ID (required with botToken) */
+  botChannel?: string;
+  
+  /** Maximum number of failures to display (default: 5) */
+  maxFailures?: number;
+  
+  /** Maximum number of lines per error detail (default: 80) */
+  maxDetailLines?: number;
+  
+  /** Maximum number of characters per error detail (default: 4000) */
+  maxDetailChars?: number;
+  
+  /** Slack channel override (for webhooks) */
+  channel?: string;
+  
+  /** Request timeout in milliseconds (default: 10000) */
+  timeoutMs?: number;
+  
+  /** Number of retry attempts (default: 2) */
+  retries?: number;
+  
+  /** Delay between retries in milliseconds (default: 500) */
+  retryDelayMs?: number;
+}
+
+/**
+ * Resolved configuration with all defaults applied
+ */
+export interface ResolvedReporterOptions {
+  notifyMode?: PlaywrightSlackNotifyMode;
+  showErrorDetails: boolean;
+  errorDetailsInThread: boolean;
+  botToken?: string;
+  botChannel?: string;
+  maxFailures: number;
+  maxDetailLines: number;
+  maxDetailChars: number;
+  timeoutMs: number;
+  retries: number;
+  retryDelayMs: number;
+  channel?: string;
+}
+
+/**
+ * Represents a single test failure
+ */
+export interface Failure {
+  /** Full title path joined with ' › ' */
+  title: string;
+  
+  /** Test name only (last element of title path) */
+  testName: string;
+  
+  /** Project/browser name (e.g., 'chromium') */
+  project?: string;
+  
+  /** Relative file path with line and column (e.g., 'e2e/test.spec.ts:10:5') */
+  location?: string;
+  
+  /** Full error message including stack trace and code snippet */
+  error?: string;
+}

--- a/src/reporterTypes.ts
+++ b/src/reporterTypes.ts
@@ -17,6 +17,14 @@ export interface PlaywrightSlackReporterOptions {
   /** Whether to post error details in a thread (requires Bot Token mode) */
   errorDetailsInThread?: boolean;
   
+  /**
+   * Whether to split thread messages per test case (only applies when errorDetailsInThread is true)
+   * - false (default): Post all errors in one thread message
+   * - true: Post each test error as a separate thread message
+   * @default false
+   */
+  splitThreadMessagePerTest?: boolean;
+  
   /** Slack Bot Token (alternative to webhook) */
   botToken?: string;
   
@@ -52,6 +60,7 @@ export interface ResolvedReporterOptions {
   notifyMode?: PlaywrightSlackNotifyMode;
   showErrorDetails: boolean;
   errorDetailsInThread: boolean;
+  splitThreadMessagePerTest: boolean;
   botToken?: string;
   botChannel?: string;
   maxFailures: number;

--- a/tests/playwright-reporter.test.ts
+++ b/tests/playwright-reporter.test.ts
@@ -592,4 +592,63 @@ describe('PlaywrightSlackReporter', () => {
     assert.match(mainText, /first error/);
     assert.match(mainText, /second error/);
   });
+
+  it('displays detailed timeout error with code snippet in thread', async () => {
+    process.env.SLACK_BOT_TOKEN = 'xoxb-test-token';
+    process.env.SLACK_BOT_CHANNEL_ID = 'C1234567890';
+
+    const payloads: Array<{ text: string; thread_ts?: string }> = [];
+    const calls = { count: 0 };
+    globalThis.fetch = (async (_input: unknown, init?: RequestInit) => {
+      calls.count += 1;
+      const body = JSON.parse(String(init?.body ?? '{}')) as { text: string; thread_ts?: string };
+      payloads.push(body);
+      if (calls.count === 1) {
+        return new Response('{"ok":true,"ts":"1742600000.123456"}', { status: 200 });
+      }
+      return new Response('{"ok":true,"ts":"1742600001.123456"}', { status: 200 });
+    }) as typeof fetch;
+
+    const reporter = new PlaywrightSlackReporter({ errorDetailsInThread: true });
+    reporter.onTestEnd?.(
+      {
+        titlePath: () => ['chromium', 'timeout test'],
+        parent: { project: () => ({ name: 'chromium' }) },
+        location: { file: 'e2e/timeout.spec.ts', line: 10, column: 2 },
+      } as any,
+      {
+        status: 'timedOut',
+        error: {
+          message: 'Test timeout of 30000ms exceeded.',
+        },
+        errors: [
+          {
+            message: 'Test timeout of 30000ms exceeded.',
+          },
+          {
+            message: 'page.click: Timeout 30000ms exceeded.',
+            stack:
+              'Error: page.click: Timeout 30000ms exceeded.\n\n  10 |   await page.goto(\'/\');\n> 11 |   await page.click(\'#submit-button\');\n     |              ^\n  12 | });\n\n    at e2e/timeout.spec.ts:11:14',
+          },
+        ],
+      } as any,
+    );
+
+    await reporter.onEnd?.({ status: 'failed' } as any);
+
+    assert.equal(payloads.length, 2);
+    
+    // Main message should contain test name
+    assert.match(payloads[0].text, /timeout test/);
+    assert.equal(payloads[0].thread_ts, undefined);
+    
+    // Thread message should contain detailed timeout error with code snippet
+    assert.equal(payloads[1].thread_ts, '1742600000.123456');
+    const threadText = payloads[1].text;
+    assert.match(threadText, /Test timeout of 30000ms exceeded/);
+    assert.match(threadText, /---/); // Separator between errors
+    assert.match(threadText, /page\.click: Timeout 30000ms exceeded/);
+    assert.match(threadText, />.*11.*await page\.click/); // Code snippet with line marker
+    assert.match(threadText, /timeout\.spec\.ts:11:14/);
+  });
 });

--- a/tests/playwright-reporter.test.ts
+++ b/tests/playwright-reporter.test.ts
@@ -57,8 +57,9 @@ describe('PlaywrightSlackReporter', () => {
       {
         status: 'failed',
         error: {
-          message:
-            'Error: expect(page).toHaveTitle(expected) failed\\nExpected: "Playwright"\\nReceived: "Playwright E2E"',
+          message: 'Error: expect(page).toHaveTitle(expected) failed',
+          stack:
+            'Error: expect(page).toHaveTitle(expected) failed\nExpected: "Playwright"\nReceived: "Playwright E2E"\n    at e2e/basic.spec.ts:3:5',
         },
       } as any,
     );
@@ -68,6 +69,9 @@ describe('PlaywrightSlackReporter', () => {
     const payload = JSON.parse(seen.body) as { text: string };
     assert.equal(typeof payload.text, 'string');
     assert.match(payload.text, /Playwright E2E result: failed/);
+    assert.match(payload.text, /:large_green_circle: Passed: 0/);
+    assert.match(payload.text, /:red_circle: Failed: 1/);
+    assert.match(payload.text, /:red_circle:/);
     assert.match(payload.text, /Expected: "Playwright"/);
     assert.match(payload.text, /Received: "Playwright E2E"/);
   });
@@ -144,8 +148,9 @@ describe('PlaywrightSlackReporter', () => {
       {
         status: 'failed',
         error: {
-          message:
-            'Error: expect(page).toHaveTitle(expected) failed\\nExpected: "Playwright"\\nReceived: "Playwright E2E"',
+          message: 'Error: expect(page).toHaveTitle(expected) failed',
+          stack:
+            'Error: expect(page).toHaveTitle(expected) failed\n\n  8 | test("thread details test", async ({ page }) => {\n  9 |   await page.goto("https://example.com");\n> 10 |   await expect(page).toHaveTitle("Wrong Title");\n    |         ^\n  11 | });\n\nExpected: "Playwright"\nReceived: "Playwright E2E"\n    at e2e/thread.spec.ts:10:2',
         },
       } as any,
     );
@@ -155,10 +160,24 @@ describe('PlaywrightSlackReporter', () => {
     assert.equal(payloads.length, 2);
     assert.equal(payloads[0].thread_ts, undefined);
     assert.match(payloads[0].text, /Playwright E2E result: failed/);
+    assert.match(payloads[0].text, /:large_green_circle: Passed: 0/);
+    assert.match(payloads[0].text, /:red_circle: Failed: 1/);
+    
+    // Main post should contain only test name (not full path) with red circle
+    assert.match(payloads[0].text, /:red_circle: thread details test/);
+    assert.doesNotMatch(payloads[0].text, /chromium › thread details test/);
+    assert.doesNotMatch(payloads[0].text, /e2e\/thread\.spec\.ts/);
+    
+    // Thread post should contain full details including code snippet
     assert.equal(payloads[1].thread_ts, '1742600000.123456');
-    assert.match(payloads[1].text, /Failed test error reasons:/);
+    assert.match(payloads[1].text, /\*\*chromium › thread details test\*\*/);
+    assert.match(payloads[1].text, /chromium e2e\/thread\.spec\.ts:10:2/);
+    assert.match(payloads[1].text, /```/);
     assert.match(payloads[1].text, /Expected: "Playwright"/);
-    assert.doesNotMatch(payloads[1].text, /details:/);
+    assert.match(payloads[1].text, /Received: "Playwright E2E"/);
+    // Should contain code snippet
+    assert.match(payloads[1].text, />.*10.*await expect\(page\)\.toHaveTitle/);
+    assert.doesNotMatch(payloads[1].text, /Failed test error reasons:/);
   });
 
   it('uses parent ts returned from bot API as thread ts for detail post', async () => {
@@ -339,5 +358,86 @@ describe('PlaywrightSlackReporter', () => {
     assert.match(payload.text, /apps\/web\/e2e\/contact-form\.spec\.ts:114:1/);
     // Should NOT contain the full absolute path
     assert.doesNotMatch(payload.text, new RegExp(cwd.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')));
+  });
+
+  it('posts multiple errors with test names in thread', async () => {
+    process.env.SLACK_BOT_TOKEN = 'xoxb-test-token';
+    process.env.SLACK_BOT_CHANNEL_ID = 'C1234567890';
+
+    const payloads: Array<{ text: string; thread_ts?: string }> = [];
+    const calls = { count: 0 };
+    globalThis.fetch = (async (_input: unknown, init?: RequestInit) => {
+      calls.count += 1;
+      const body = JSON.parse(String(init?.body ?? '{}')) as { text: string; thread_ts?: string };
+      payloads.push(body);
+      if (calls.count === 1) {
+        return new Response('{"ok":true,"ts":"1742600000.123456"}', { status: 200 });
+      }
+      return new Response('{"ok":true,"ts":"1742600001.123456"}', { status: 200 });
+    }) as typeof fetch;
+
+    const reporter = new PlaywrightSlackReporter({ errorDetailsInThread: true });
+    
+    // First failure
+    reporter.onTestEnd?.(
+      {
+        titlePath: () => ['chromium', 'login test'],
+        parent: { project: () => ({ name: 'chromium' }) },
+        location: { file: 'e2e/auth.spec.ts', line: 15, column: 1 },
+      } as any,
+      {
+        status: 'failed',
+        error: {
+          message: 'Error: Login failed\nLocator timeout',
+        },
+      } as any,
+    );
+    
+    // Second failure
+    reporter.onTestEnd?.(
+      {
+        titlePath: () => ['firefox', 'form test'],
+        parent: { project: () => ({ name: 'firefox' }) },
+        location: { file: 'e2e/form.spec.ts', line: 25, column: 1 },
+      } as any,
+      {
+        status: 'failed',
+        error: {
+          message: 'Error: Form submission failed\nExpected 200, received 500',
+        },
+      } as any,
+    );
+
+    await reporter.onEnd?.({ status: 'failed' } as any);
+
+    assert.equal(payloads.length, 2);
+    
+    // Main post should contain only test names (not full paths)
+    const mainText = payloads[0].text;
+    assert.match(mainText, /:red_circle: login test/);
+    assert.match(mainText, /:red_circle: form test/);
+    assert.doesNotMatch(mainText, /chromium › login test/);
+    assert.doesNotMatch(mainText, /e2e\/auth\.spec\.ts/);
+    assert.doesNotMatch(mainText, /e2e\/form\.spec\.ts/);
+    
+    // Thread post should contain full details
+    assert.equal(payloads[1].thread_ts, '1742600000.123456');
+    const threadText = payloads[1].text;
+    
+    // Should contain both test names with full paths
+    assert.match(threadText, /\*\*chromium › login test\*\*/);
+    assert.match(threadText, /\*\*firefox › form test\*\*/);
+    
+    // Should contain both locations
+    assert.match(threadText, /e2e\/auth\.spec\.ts:15:1/);
+    assert.match(threadText, /e2e\/form\.spec\.ts:25:1/);
+    
+    // Should contain both error messages
+    assert.match(threadText, /Login failed/);
+    assert.match(threadText, /Form submission failed/);
+    
+    // Should have code blocks
+    const codeBlockCount = (threadText.match(/```/g) || []).length;
+    assert.equal(codeBlockCount, 4); // 2 errors × 2 code blocks (open and close)
   });
 });

--- a/tests/playwright-reporter.test.ts
+++ b/tests/playwright-reporter.test.ts
@@ -440,4 +440,156 @@ describe('PlaywrightSlackReporter', () => {
     const codeBlockCount = (threadText.match(/```/g) || []).length;
     assert.equal(codeBlockCount, 4); // 2 errors × 2 code blocks (open and close)
   });
+
+  it('posts separate thread messages per test when splitThreadMessagePerTest is true', async () => {
+    process.env.SLACK_BOT_TOKEN = 'xoxb-test-token';
+    process.env.SLACK_BOT_CHANNEL_ID = 'C1234567890';
+
+    const payloads: Array<{ text: string; thread_ts?: string }> = [];
+    const calls = { count: 0 };
+    globalThis.fetch = (async (_input: unknown, init?: RequestInit) => {
+      calls.count += 1;
+      const body = JSON.parse(String(init?.body ?? '{}')) as { text: string; thread_ts?: string };
+      payloads.push(body);
+      if (calls.count === 1) {
+        return new Response('{"ok":true,"ts":"1742600000.123456"}', { status: 200 });
+      }
+      if (calls.count === 2) {
+        return new Response('{"ok":true,"ts":"1742600001.123456"}', { status: 200 });
+      }
+      return new Response('{"ok":true,"ts":"1742600002.123456"}', { status: 200 });
+    }) as typeof fetch;
+
+    const reporter = new PlaywrightSlackReporter({
+      errorDetailsInThread: true,
+      splitThreadMessagePerTest: true,
+    });
+    
+    // First failure
+    reporter.onTestEnd?.(
+      {
+        titlePath: () => ['chromium', 'login test'],
+        parent: { project: () => ({ name: 'chromium' }) },
+        location: { file: 'e2e/auth.spec.ts', line: 15, column: 1 },
+      } as any,
+      {
+        status: 'failed',
+        error: {
+          message: 'Error: Login failed\nLocator timeout',
+        },
+      } as any,
+    );
+    
+    // Second failure
+    reporter.onTestEnd?.(
+      {
+        titlePath: () => ['firefox', 'form test'],
+        parent: { project: () => ({ name: 'firefox' }) },
+        location: { file: 'e2e/form.spec.ts', line: 25, column: 1 },
+      } as any,
+      {
+        status: 'failed',
+        error: {
+          message: 'Error: Form submission failed\nExpected 200, received 500',
+        },
+      } as any,
+    );
+
+    await reporter.onEnd?.({ status: 'failed' } as any);
+
+    // Should make 3 API calls: 1 main message + 2 thread messages
+    assert.equal(payloads.length, 3);
+    
+    // Main post should contain only test names (not full paths)
+    const mainText = payloads[0].text;
+    assert.equal(payloads[0].thread_ts, undefined);
+    assert.match(mainText, /:red_circle: login test/);
+    assert.match(mainText, /:red_circle: form test/);
+    assert.doesNotMatch(mainText, /chromium › login test/);
+    assert.doesNotMatch(mainText, /e2e\/auth\.spec\.ts/);
+    assert.doesNotMatch(mainText, /e2e\/form\.spec\.ts/);
+    
+    // First thread message should contain only first test details
+    assert.equal(payloads[1].thread_ts, '1742600000.123456');
+    const firstThreadText = payloads[1].text;
+    assert.match(firstThreadText, /\*\*chromium › login test\*\*/);
+    assert.match(firstThreadText, /e2e\/auth\.spec\.ts:15:1/);
+    assert.match(firstThreadText, /Login failed/);
+    assert.match(firstThreadText, /```/);
+    // Should NOT contain second test details
+    assert.doesNotMatch(firstThreadText, /firefox › form test/);
+    assert.doesNotMatch(firstThreadText, /e2e\/form\.spec\.ts/);
+    assert.doesNotMatch(firstThreadText, /Form submission failed/);
+    
+    // Second thread message should contain only second test details
+    assert.equal(payloads[2].thread_ts, '1742600000.123456');
+    const secondThreadText = payloads[2].text;
+    assert.match(secondThreadText, /\*\*firefox › form test\*\*/);
+    assert.match(secondThreadText, /e2e\/form\.spec\.ts:25:1/);
+    assert.match(secondThreadText, /Form submission failed/);
+    assert.match(secondThreadText, /```/);
+    // Should NOT contain first test details
+    assert.doesNotMatch(secondThreadText, /chromium › login test/);
+    assert.doesNotMatch(secondThreadText, /e2e\/auth\.spec\.ts/);
+    assert.doesNotMatch(secondThreadText, /Login failed/);
+  });
+
+  it('falls back to combined thread message when splitThreadMessagePerTest is true but bot is not configured', async () => {
+    process.env.SLACK_WEBHOOK_URL = 'https://example.invalid/webhook';
+    delete process.env.SLACK_BOT_TOKEN;
+    delete process.env.SLACK_BOT_CHANNEL_ID;
+
+    const payloads: Array<{ text: string }> = [];
+    globalThis.fetch = (async (_input: unknown, init?: RequestInit) => {
+      payloads.push(JSON.parse(String(init?.body ?? '{}')) as { text: string });
+      return new Response('ok', { status: 200 });
+    }) as typeof fetch;
+
+    const reporter = new PlaywrightSlackReporter({
+      errorDetailsInThread: true,
+      splitThreadMessagePerTest: true,
+    });
+    
+    reporter.onTestEnd?.(
+      {
+        titlePath: () => ['chromium', 'first test'],
+        parent: { project: () => ({ name: 'chromium' }) },
+        location: { file: 'e2e/test1.spec.ts', line: 10, column: 1 },
+      } as any,
+      {
+        status: 'failed',
+        error: {
+          message: 'Error: first error',
+        },
+      } as any,
+    );
+    
+    reporter.onTestEnd?.(
+      {
+        titlePath: () => ['firefox', 'second test'],
+        parent: { project: () => ({ name: 'firefox' }) },
+        location: { file: 'e2e/test2.spec.ts', line: 20, column: 1 },
+      } as any,
+      {
+        status: 'failed',
+        error: {
+          message: 'Error: second error',
+        },
+      } as any,
+    );
+
+    await reporter.onEnd?.({ status: 'failed' } as any);
+
+    // Should only make 1 API call with inline details
+    assert.equal(payloads.length, 1);
+    const mainText = payloads[0].text;
+    
+    // Should contain both test details inline
+    assert.match(mainText, /first test/);
+    assert.match(mainText, /second test/);
+    assert.match(mainText, /e2e\/test1\.spec\.ts:10:1/);
+    assert.match(mainText, /e2e\/test2\.spec\.ts:20:1/);
+    assert.match(mainText, /first error/);
+    assert.match(mainText, /second error/);
+  });
 });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,6 +4,9 @@
       "ES2024",
       "DOM"
     ],
+    "types": [
+      "node"
+    ],
     "target": "ES2024",
     "module": "NodeNext",
     "moduleResolution": "NodeNext",


### PR DESCRIPTION
## リファクタリング・バグ修正・機能追加

### 概要

コードベースの大規模リファクタリング、タイムアウトエラー時のコードスニペット表示修正、およびスレッドメッセージ分割オプションの追加を行いました。

---

### 1. リファクタリング（Phase 1 & 2）

単一ファイルに混在していた責務を分離し、保守性・テスタビリティを向上させました。

**新規作成ファイル**

| ファイル | 役割 |
|---|---|
| `src/constants.ts` | 環境変数名・デフォルト値・絵文字定数 |
| `src/pathUtils.ts` | パス変換ユーティリティ |
| `src/formatters.ts` | エラーテキスト整形ユーティリティ |
| `src/reporterTypes.ts` | 型定義 |
| `src/reporterConfig.ts` | 設定管理 |
| `src/messageBuilder.ts` | Slackメッセージ構築 |
| `src/notificationSender.ts` | Slack送信ロジック |

**主な変更**

- `playwrightReporter.ts` を 308 行 → 115 行（-62.7%）に削減
- マジックナンバーをすべて `DEFAULTS` 定数に置き換え
- 未使用の `formatErrorSummary()` を削除
- `convertStackTraceToRelativePaths()` の正規表現ロジックを `escapeRegex()` ヘルパーに分離
- 全公開関数に JSDoc を追加

---

### 2. バグ修正：タイムアウトエラー時のコードスニペット欠落

**問題**

タイムアウトエラー発生時に、原因となった操作のコードスニペットが Slack に表示されませんでした。  
Playwright はタイムアウトエラーを `result.errors` 配列（複数）として格納しますが、従来の実装は `result.error`（単一）のみを参照していました。

**修正前**
```
Test timeout of 30000ms exceeded.
```

**修正後**
```
Test timeout of 30000ms exceeded.

---

page.click: Timeout 30000ms exceeded.

  10 |   await page.goto('/');
> 11 |   await page.click('#submit-button');
     |              ^
  12 | });

    at e2e/timeout.spec.ts:11:14
```

**変更箇所**: `src/playwrightReporter.ts`

- `result.errors` 配列を優先して収集し、`---` 区切りで結合
- `result.errors` が空の場合は `result.error` にフォールバック
- `result.error.snippet` が存在する場合はスタックトレースに追記

---

### 3. 新機能：`splitThreadMessagePerTest` オプション

Bot Token 方式のスレッド投稿で、失敗テストごとに個別のスレッドメッセージを送信できるオプションを追加しました。

**設定例**

```ts
export default defineConfig({
  reporter: [
    ['@sugityan/playwright-slack-notification/reporter', {
      errorDetailsInThread: true,
      splitThreadMessagePerTest: true,
    }],
  ],
});
```

**動作**

| オプション | 動作 |
|---|---|
| `false`（デフォルト） | 全エラーを1つのスレッドメッセージにまとめて投稿 |
| `true` | 失敗テストごとに個別のスレッドメッセージを投稿 |

- Bot Token 未設定の場合は Webhook インライン表示にフォールバック
- Slack の 40,000 文字制限によるメッセージ欠落を回避
- 破壊的変更なし（デフォルトは既存動作を維持）

---

### テスト結果

```
✅ 25/25 tests passing
```

| 種別 | 件数 |
|---|---|
| 既存テスト（後方互換性確認） | 22件 |
| タイムアウトエラー修正の新規テスト | 1件 |
| `splitThreadMessagePerTest` の新規テスト | 2件 |

---

### 破壊的変更

なし。すべての変更は既存の外部 API を維持しています。
