### PR TITLE
エラーハンドリングの改善: 環境変数未設定時に赤色のエラーメッセージを表示

### DIFF
--- a/src/notificationSender.ts
+++ b/src/notificationSender.ts
@@ -111,7 +111,7 @@ async function sendViaWebhook(config: ReporterConfig, message: string): Promise<
   const webhookUrl = config.getWebhookUrl();
   
   if (!webhookUrl) {
-    // No webhook URL configured, silently skip
+    console.error('PlaywrightSlackReporter: SLACK_WEBHOOK_URL is not set');
     return;
   }
 

--- a/src/notificationSender.ts
+++ b/src/notificationSender.ts
@@ -10,7 +10,7 @@ import type { ReporterConfig } from './reporterConfig.ts';
 import { sendSlackBotMessage } from './slackBotClient.ts';
 import { sendSlackWebhook } from './slackClient.ts';
 import type { SlackWebhookPayload } from './types.ts';
-import { validateWebhookUrl } from './utils.ts';
+import { red, validateWebhookUrl } from './utils.ts';
 
 /**
  * Sends a Slack notification using the appropriate method based on configuration
@@ -116,7 +116,7 @@ async function sendViaWebhook(config: ReporterConfig, message: string): Promise<
   const webhookUrl = config.getWebhookUrl();
   
   if (!webhookUrl) {
-    console.error('PlaywrightSlackReporter: SLACK_WEBHOOK_URL is not set');
+    console.error(red('PlaywrightSlackReporter: SLACK_WEBHOOK_URL is not set'));
     return;
   }
 

--- a/src/notificationSender.ts
+++ b/src/notificationSender.ts
@@ -35,6 +35,11 @@ export async function sendNotification(
   threadMessages?: string[],
 ): Promise<void> {
   try {
+    // If errorDetailsInThread is enabled but bot config is missing, do not send via webhook
+    if (config.errorDetailsInThread && !config.canUseBotThread) {
+      return;
+    }
+
     // Bot thread mode: send main message, then thread details
     if (config.canUseBotThread && config.botToken && config.botChannel) {
       await sendViaBotWithThread(config, mainMessage, threadMessages);

--- a/src/reporterConfig.ts
+++ b/src/reporterConfig.ts
@@ -52,13 +52,9 @@ export class ReporterConfig {
     // Compute whether bot thread mode is available
     this.canUseBotThread = this.errorDetailsInThread && !!this.botToken && !!this.botChannel;
 
-    // Warn if thread mode is requested but not available
+    // Error if thread mode is requested but not available
     if (this.errorDetailsInThread && !this.canUseBotThread) {
-      console.warn(
-        'PlaywrightSlackReporter: errorDetailsInThread is enabled but Slack Bot config is missing. ' +
-        'Set botToken/botChannel or SLACK_BOT_TOKEN/SLACK_BOT_CHANNEL_ID. ' +
-        'Falling back to webhook inline details.'
-      );
+      console.error('PlaywrightSlackReporter: errorDetailsInThread is enabled but SLACK_BOT_TOKEN or SLACK_BOT_CHANNEL_ID is not set');
     }
   }
 

--- a/src/reporterConfig.ts
+++ b/src/reporterConfig.ts
@@ -4,6 +4,7 @@
 
 import { DEFAULTS, ENV_VARS } from './constants.ts';
 import type { PlaywrightSlackNotifyMode, PlaywrightSlackReporterOptions, ResolvedReporterOptions } from './reporterTypes.ts';
+import { red } from './utils.ts';
 
 /**
  * Configuration class that manages reporter options and provides computed properties
@@ -54,7 +55,7 @@ export class ReporterConfig {
 
     // Error if thread mode is requested but not available
     if (this.errorDetailsInThread && !this.canUseBotThread) {
-      console.error('PlaywrightSlackReporter: errorDetailsInThread is enabled but SLACK_BOT_TOKEN or SLACK_BOT_CHANNEL_ID is not set');
+      console.error(red('PlaywrightSlackReporter: errorDetailsInThread is enabled but SLACK_BOT_TOKEN or SLACK_BOT_CHANNEL_ID is not set'));
     }
   }
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -38,3 +38,21 @@ export function toInt(value: string | null): number | undefined {
   if (!Number.isFinite(num)) return undefined;
   return num;
 }
+
+/**
+ * ANSI color codes for terminal output
+ */
+const ANSI_COLORS = {
+  RED: '\x1b[31m',
+  RESET: '\x1b[0m',
+} as const;
+
+/**
+ * Wraps text in red color for terminal output
+ * 
+ * @param text - The text to colorize
+ * @returns Text wrapped with ANSI red color codes
+ */
+export function red(text: string): string {
+  return `${ANSI_COLORS.RED}${text}${ANSI_COLORS.RESET}`;
+}

--- a/tests/playwright-reporter.test.ts
+++ b/tests/playwright-reporter.test.ts
@@ -219,7 +219,7 @@ describe('PlaywrightSlackReporter', () => {
     assert.equal(payloads[1].thread_ts, '1742600000.123456');
   });
 
-  it('falls back to inline details when bot settings are missing', async () => {
+  it('does not send when errorDetailsInThread is true but bot settings are missing', async () => {
     process.env.SLACK_WEBHOOK_URL = 'https://example.invalid/webhook';
     delete process.env.SLACK_BOT_TOKEN;
     delete process.env.SLACK_BOT_CHANNEL_ID;
@@ -248,10 +248,8 @@ describe('PlaywrightSlackReporter', () => {
 
     await reporter.onEnd?.({ status: 'failed' } as any);
 
-    assert.equal(payloads.length, 1);
-    assert.equal(payloads[0].thread_ts, undefined);
-    assert.match(payloads[0].text, /details:/);
-    assert.match(payloads[0].text, /Expected: "Playwright"/);
+    // Should not send any notification when errorDetailsInThread is true but bot config is missing
+    assert.equal(payloads.length, 0);
   });
 
   it('does not include error content when showErrorDetails is false (webhook mode)', async () => {
@@ -534,7 +532,7 @@ describe('PlaywrightSlackReporter', () => {
     assert.doesNotMatch(secondThreadText, /Login failed/);
   });
 
-  it('falls back to combined thread message when splitThreadMessagePerTest is true but bot is not configured', async () => {
+  it('does not send when splitThreadMessagePerTest is true but bot is not configured', async () => {
     process.env.SLACK_WEBHOOK_URL = 'https://example.invalid/webhook';
     delete process.env.SLACK_BOT_TOKEN;
     delete process.env.SLACK_BOT_CHANNEL_ID;
@@ -580,17 +578,8 @@ describe('PlaywrightSlackReporter', () => {
 
     await reporter.onEnd?.({ status: 'failed' } as any);
 
-    // Should only make 1 API call with inline details
-    assert.equal(payloads.length, 1);
-    const mainText = payloads[0].text;
-    
-    // Should contain both test details inline
-    assert.match(mainText, /first test/);
-    assert.match(mainText, /second test/);
-    assert.match(mainText, /e2e\/test1\.spec\.ts:10:1/);
-    assert.match(mainText, /e2e\/test2\.spec\.ts:20:1/);
-    assert.match(mainText, /first error/);
-    assert.match(mainText, /second error/);
+    // Should not send any notification when errorDetailsInThread is true but bot config is missing
+    assert.equal(payloads.length, 0);
   });
 
   it('displays detailed timeout error with code snippet in thread', async () => {


### PR DESCRIPTION
Generated with Claude Code

## What

環境変数未設定時のエラーハンドリングを改善し、設定不備を明確に検出できるようにしました。

### 主な変更

#### 1. 環境変数未設定時のエラー表示

**SLACK_WEBHOOK_URL が未設定の場合:**
```
PlaywrightSlackReporter: SLACK_WEBHOOK_URL is not set
```
- 赤色のエラーメッセージを表示
- 通知は送信されない

**errorDetailsInThread: true で Bot 設定が未設定の場合:**
```
PlaywrightSlackReporter: errorDetailsInThread is enabled but SLACK_BOT_TOKEN or SLACK_BOT_CHANNEL_ID is not set
```
- 赤色のエラーメッセージを表示
- Webhook URL が設定されていても通知は送信されない
- ユーザーが意図したBot モードの設定不備に気づきやすくなる

#### 2. ANSI カラーコードによる視認性向上

- `src/utils.ts` に `red()` 関数を追加
- エラーメッセージを赤色で表示し、ターミナルでの視認性を向上

#### 3. エラーハンドリングの動作変更

**変更前:**
- 環境変数が未設定でも静かに終了（ログなし）
- `errorDetailsInThread: true` で Bot 設定が不足していても Webhook にフォールバック

**変更後:**
- 環境変数が未設定の場合は赤色のエラーメッセージを表示
- `errorDetailsInThread: true` で Bot 設定が不足している場合、Webhook も送信しない
- 設定不備を明確に検出可能

### 技術的詳細

#### エラー表示の実装

**src/utils.ts:**
```typescript
export function red(text: string): string {
  return `${ANSI_COLORS.RED}${text}${ANSI_COLORS.RESET}`;
}
```

**src/reporterConfig.ts:**
```typescript
if (this.errorDetailsInThread && !this.canUseBotThread) {
  console.error(red('PlaywrightSlackReporter: errorDetailsInThread is enabled but SLACK_BOT_TOKEN or SLACK_BOT_CHANNEL_ID is not set'));
}
```

**src/notificationSender.ts:**
```typescript
if (!webhookUrl) {
  console.error(red('PlaywrightSlackReporter: SLACK_WEBHOOK_URL is not set'));
  return;
}

// errorDetailsInThread が有効だが Bot 設定が不足している場合、Webhook も送信しない
if (config.errorDetailsInThread && !config.canUseBotThread) {
  return;
}
```

#### テストの更新

以下のテストケースを新しい動作に合わせて更新:
- `does not send when errorDetailsInThread is true but bot settings are missing`
- `does not send when splitThreadMessagePerTest is true but bot is not configured`

### エラーメッセージの方針

プロダクトのエラー処理として、以下の方針を採用:
- エラーメッセージはシンプルに事実のみを伝える
- 対処法の説明やガイドへのリンクは含めない
- ユーザーが自身で対処法を判断できるようにする

### 動作確認

✅ 全テスト成功（25/25）
✅ ビルド成功
✅ エラーメッセージが赤色で表示される
✅ 設定不備を明確に検出可能

## Related PRs
- N/A
